### PR TITLE
Config header size

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/naip_i
   <img src="https://async-cog-reader-test-data.s3.amazonaws.com/readme/mask.jpg" width="300" /> 
 </p>
 
+### Configuration
+Configuration options are exposed through environment variables:
+- **INGESTED_BYTES_AT_OPEN** - defines the number of bytes in the first GET request at file opening (defaults to 16KB)
+
+
 ## CLI
 ```
 $ aiocogeo --help

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -1,0 +1,7 @@
+"""Configurable values exposed to user as environment variables"""
+import os
+
+# https://gdal.org/user/virtual_file_systems.html#vsicurl-http-https-ftp-files-random-access
+# Defines the number of bytes read in the first GET request at file opening
+# Can help performance when reading images with a large header
+INGESTED_BYTES_AT_OPEN = os.getenv("INGESTED_BYTES_AT_OPEN", 16384)

--- a/aiocogeo/constants.py
+++ b/aiocogeo/constants.py
@@ -1,7 +1,5 @@
 # TODO: Add more compressions
 
-HEADER_OFFSET = 16384
-
 WEB_MERCATOR_EPSG = 3857
 
 COMPRESSIONS = {

--- a/aiocogeo/filesystems.py
+++ b/aiocogeo/filesystems.py
@@ -6,7 +6,7 @@ import aioboto3
 import aiofiles
 import aiohttp
 
-from .constants import HEADER_OFFSET
+from .config import INGESTED_BYTES_AT_OPEN
 
 @dataclass
 class Filesystem(abc.ABC):
@@ -43,7 +43,7 @@ class Filesystem(abc.ABC):
 
     async def read(self, offset: int, cast_to_int: bool = False):
         if self._offset + offset > len(self.data):
-            self.data += await self.range_request(len(self.data), HEADER_OFFSET)
+            self.data += await self.range_request(len(self.data), INGESTED_BYTES_AT_OPEN)
         data = self.data[self._offset : self._offset + offset]
         self.incr(offset)
         order = "little" if self._endian == "<" else "big"

--- a/aiocogeo/tag.py
+++ b/aiocogeo/tag.py
@@ -4,7 +4,8 @@ import struct
 
 from typing import Any, Tuple, Union
 
-from .constants import TIFF_TAGS, HEADER_OFFSET
+from .config import INGESTED_BYTES_AT_OPEN
+from .constants import TIFF_TAGS
 
 # TODO: Move this somewhere more sensible
 logging.basicConfig()
@@ -78,7 +79,7 @@ class Tag:
         else:
             value_offset = await reader.read(4, cast_to_int=True)
             end_of_tag = reader.tell()
-            if value_offset + length > HEADER_OFFSET:
+            if value_offset + length > INGESTED_BYTES_AT_OPEN:
                 data = await reader.range_request(value_offset, length - 1)
             else:
                 reader.seek(value_offset)


### PR DESCRIPTION
- Adds `INGESTED_BYTES_AT_OPEN` environment variable defining number of bytes read in the first GET request at file opening (defaults to 16kb)

Ref: https://gdal.org/user/virtual_file_systems.html#vsicurl-http-https-ftp-files-random-access

closes #21 