### PR TITLE
merge consecutive range requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/naip_i
 ### Configuration
 Configuration options are exposed through environment variables:
 - **INGESTED_BYTES_AT_OPEN** - defines the number of bytes in the first GET request at file opening (defaults to 16KB)
+- **HTTP_MERGE_CONSECUTIVE_RANGES** - determines if consecutive ranges are merged into a single request (defaults to FALSE)
+
+Refer to [`aiocogeo/config.py`](https://github.com/geospatial-jeff/aiocogeo/blob/master/aiocogeo/config.py) for more details about configuration options.
 
 
 ## CLI

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -213,19 +213,17 @@ class COGReader:
         return decoded
 
     @staticmethod
-    def merge_range_requests(ranges: List[Tuple[int, int, int, int]]) -> Tuple[Tuple[int, int], List[Tuple[int, int]]]:
+    def merge_range_requests(ranges: List[Tuple[int, int, int, int]]) -> Tuple[Tuple[int, int], Tuple[Tuple[int, int, int, int]]]:
         """
         Helper function to merge consecutive range requests while keeping track of the initial ranges.  Returns an
-        iterator which yields a tuple, where the first item is a tuple with the start/end of a merged request and the
-        second item is the list of tuples where each tuple contains the original ranges and tile indices.
+        iterator which yields a tuple of tuples, where the first is a tuple with the start/end of a merged request and
+        the second is another tuple of tuples where each tuple contains the original ranges and tile indices.
 
         For example, if we have two ranges A->B and B->C representing tiles in the top row of a COG, this
         method will yield:
 
-            ((A, C), [(A,B,0,0),(B,C,1,0)]
+            ((A, C), ((A, B, 0, 0), (B, C, 1, 0)))
 
-        We must keep track of the original ranges so we can fetch the bytes for each tile by indexing into the bytes
-        returned by the merged range request, and tile indices are required for mosaicing the individual tiles.
         """
         # Create our start position (start, end)
         saved = [ranges[0][0], ranges[0][0] + ranges[0][1]]

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -11,7 +11,7 @@ import affine
 import numpy as np
 from skimage.transform import resize
 
-from .config import HTTP_MERGE_CONSECUTIVE_RANGES
+from . import config
 from .constants import PHOTOMETRIC
 from .errors import InvalidTiffError, TileNotFoundError
 from .filesystems import Filesystem
@@ -311,7 +311,7 @@ class COGReader:
             )
         ).astype(ifd.dtype)
 
-        if HTTP_MERGE_CONSECUTIVE_RANGES == "TRUE":
+        if config.HTTP_MERGE_CONSECUTIVE_RANGES == "TRUE":
             # Aggregate ranges
             ranges = []
             for idx, xtile in enumerate(range(xmin, xmax + 1)):

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -219,6 +219,11 @@ class COGReader:
         iterator which yields a tuple, where the first item is a tuple with the start/end of a merged request and the
         second item is the list of tuples where each tuple contains the original ranges and tile indices.
 
+        For example, if we have two ranges A->B and B->C representing tiles in the top row of a COG, this
+        method will yield:
+
+            ((A, C), [(A,B,0,0),(B,C,1,0)]
+
         We must keep track of the original ranges so we can fetch the bytes for each tile by indexing into the bytes
         returned by the merged range request, and tile indices are required for mosaicing the individual tiles.
         """

--- a/aiocogeo/compression.py
+++ b/aiocogeo/compression.py
@@ -18,7 +18,6 @@ class Compression(metaclass=abc.ABCMeta):
     Predictor: Optional[Tag]
     JPEGTables: Optional[Tag]
 
-
     @property
     @abc.abstractmethod
     def bands(self) -> int:
@@ -48,17 +47,16 @@ class Compression(metaclass=abc.ABCMeta):
 
     def _decompress_mask(self, tile: bytes) -> np.ndarray:
         """Internal method to decompress a binary mask and rescale to uint8"""
-        decoded = np.frombuffer(imagecodecs.zlib_decode(tile), np.dtype('uint8'))
-        mask = np.unpackbits(decoded).reshape(self.TileHeight.value, self.TileWidth.value) * 255
+        decoded = np.frombuffer(imagecodecs.zlib_decode(tile), np.dtype("uint8"))
+        mask = (
+            np.unpackbits(decoded).reshape(self.TileHeight.value, self.TileWidth.value)
+            * 255
+        )
         return mask
 
     def _reshape(self, arr: np.ndarray) -> np.ndarray:
         """Internal method to reshape an array to the size expected by the IFD"""
-        return arr.reshape(
-            self.TileHeight.value,
-            self.TileWidth.value,
-            self.bands,
-        )
+        return arr.reshape(self.TileHeight.value, self.TileWidth.value, self.bands,)
 
     def _unpredict(self, arr: np.ndarray) -> None:
         """Internal method to unpredict if there is horizontal differencing"""
@@ -95,6 +93,8 @@ class Compression(metaclass=abc.ABCMeta):
 
     def _deflate(self, tile: bytes) -> np.ndarray:
         """Internal method to decompress DEFLATE image bytes and convert to numpy array"""
-        decoded = self._reshape(np.frombuffer(imagecodecs.zlib_decode(tile), self.dtype))
+        decoded = self._reshape(
+            np.frombuffer(imagecodecs.zlib_decode(tile), self.dtype)
+        )
         self._unpredict(decoded)
         return np.rollaxis(decoded, 2, 0)

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -4,9 +4,17 @@ import os
 import logging
 
 # Changes the log level
-LOG_LEVEL: str = os.getenv("LOG_LEVEL", "WARN")
+LOG_LEVEL: str = os.getenv("LOG_LEVEL", "ERROR")
+
+print(os.environ)
 
 # https://gdal.org/user/virtual_file_systems.html#vsicurl-http-https-ftp-files-random-access
 # Defines the number of bytes read in the first GET request at file opening
 # Can help performance when reading images with a large header
 INGESTED_BYTES_AT_OPEN: int = os.getenv("INGESTED_BYTES_AT_OPEN", 16384)
+
+
+# https://trac.osgeo.org/gdal/wiki/ConfigOptions#GDAL_HTTP_MERGE_CONSECUTIVE_RANGES
+# Determines if consecutive range requests are merged into a single request, reducing the number of HTTP GET range
+# requests required to read consecutive internal image tiles
+HTTP_MERGE_CONSECUTIVE_RANGES: str = os.getenv("HTTP_MERGE_CONSECUTIVE_RANGES", "FALSE").upper()

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -17,4 +17,6 @@ INGESTED_BYTES_AT_OPEN: int = os.getenv("INGESTED_BYTES_AT_OPEN", 16384)
 # https://trac.osgeo.org/gdal/wiki/ConfigOptions#GDAL_HTTP_MERGE_CONSECUTIVE_RANGES
 # Determines if consecutive range requests are merged into a single request, reducing the number of HTTP GET range
 # requests required to read consecutive internal image tiles
-HTTP_MERGE_CONSECUTIVE_RANGES: str = os.getenv("HTTP_MERGE_CONSECUTIVE_RANGES", "FALSE").upper()
+HTTP_MERGE_CONSECUTIVE_RANGES: str = os.getenv(
+    "HTTP_MERGE_CONSECUTIVE_RANGES", "FALSE"
+).upper()

--- a/aiocogeo/ifd.py
+++ b/aiocogeo/ifd.py
@@ -9,11 +9,13 @@ from .constants import COMPRESSIONS, INTERLEAVE, SAMPLE_DTYPES
 from .filesystems import Filesystem
 from .tag import Tag
 
+
 @dataclass
 class BaseIFD:
     next_ifd_offset: int
     tag_count: int
     _file_reader: Filesystem
+
 
 @dataclass
 class RequiredTags:
@@ -30,6 +32,7 @@ class RequiredTags:
     TileOffsets: Tag
     TileWidth: Tag
 
+
 @dataclass
 class OptionalTags:
     NewSubfileType: Tag = None
@@ -40,9 +43,9 @@ class OptionalTags:
     ModelPixelScaleTag: Tag = None
     ModelTiepointTag: Tag = None
 
+
 @dataclass
 class IFD(OptionalTags, Compression, RequiredTags, BaseIFD):
-
     @property
     def compression(self) -> str:
         """Return the compression of the IFD"""
@@ -85,10 +88,13 @@ class IFD(OptionalTags, Compression, RequiredTags, BaseIFD):
         # # https://www.awaresystems.be/imaging/tiff/tifftags/newsubfiletype.html
         # # https://gdal.org/drivers/raster/gtiff.html#internal-nodata-masks
         if self.NewSubfileType:
-            if self.NewSubfileType.value[2] == 1 and self.PhotometricInterpretation.value == 4 and self.compression == "deflate":
+            if (
+                self.NewSubfileType.value[2] == 1
+                and self.PhotometricInterpretation.value == 4
+                and self.compression == "deflate"
+            ):
                 return True
         return False
-
 
     @property
     def tile_count(self) -> Tuple[int, int]:

--- a/aiocogeo/scripts/cli.py
+++ b/aiocogeo/scripts/cli.py
@@ -26,16 +26,18 @@ def _get_ifd_stats(ifds):
     for idx, ifd in enumerate(ifds):
         tile_sizes = [b / 1000 for b in ifd.TileByteCounts.value]
         mean_tile_size = round(sum(tile_sizes) / len(tile_sizes), 3)
-        ifd_stats.append({
-            'id': idx,
-            'size': (ifd.ImageWidth.value, ifd.ImageHeight.value),
-            'block_size': (ifd.TileWidth.value, ifd.TileHeight.value),
-            'tile_sizes': {
-                'min': min(tile_sizes),
-                'max': max(tile_sizes),
-                'mean': mean_tile_size
+        ifd_stats.append(
+            {
+                "id": idx,
+                "size": (ifd.ImageWidth.value, ifd.ImageHeight.value),
+                "block_size": (ifd.TileWidth.value, ifd.TileHeight.value),
+                "tile_sizes": {
+                    "min": min(tile_sizes),
+                    "max": max(tile_sizes),
+                    "mean": mean_tile_size,
+                },
             }
-        })
+        )
     return ifd_stats
 
 
@@ -56,28 +58,29 @@ def _create_ifd_table(ifds, start="\t"):
         )
     return table
 
+
 def _create_json_info(cog):
     profile = cog.profile
 
     info = {
         "file": cog.filepath,
         "profile": {
-            "width": profile['width'],
-            "height": profile['height'],
-            "bands": profile['count'],
-            "dtype": profile['dtype'],
-            "crs": profile['crs'],
-            "origin": (profile['transform'].c, profile['transform'].f),
-            "resolution": (profile['transform'].a, profile['transform'].e),
+            "width": profile["width"],
+            "height": profile["height"],
+            "bands": profile["count"],
+            "dtype": profile["dtype"],
+            "crs": profile["crs"],
+            "origin": (profile["transform"].c, profile["transform"].f),
+            "resolution": (profile["transform"].a, profile["transform"].e),
             "bbox": cog.bounds,
             "compression": cog.ifds[0].compression,
-            "internal_mask": cog.is_masked
+            "internal_mask": cog.is_masked,
         },
-        "ifd": _get_ifd_stats(cog.ifds)
+        "ifd": _get_ifd_stats(cog.ifds),
     }
 
     if cog.is_masked:
-        info['mask_ifd'] = _get_ifd_stats(cog.mask_ifds)
+        info["mask_ifd"] = _get_ifd_stats(cog.mask_ifds)
 
     return info
 
@@ -85,12 +88,12 @@ def _create_json_info(cog):
 @app.command(
     short_help="Read COG metadata.",
     help="Read COG profile, IFD, and mask IFD metadata.",
-    no_args_is_help=True
+    no_args_is_help=True,
 )
 @coro
 async def info(
     filepath: str = typer.Argument(..., file_okay=True),
-    json: bool = typer.Option(False, show_default=True, help="JSON-formatted response")
+    json: bool = typer.Option(False, show_default=True, help="JSON-formatted response"),
 ):
     sep = 25
     async with COGReader(filepath) as cog:
@@ -130,7 +133,7 @@ async def info(
 @app.command(
     short_help="Create OGC TileMatrixSet.",
     help="Create OGC TileMatrixSet representation of the COG where each IFD is a unique tile matrix.",
-    no_args_is_help=True
+    no_args_is_help=True,
 )
 @coro
 async def create_tms(filepath: str):

--- a/aiocogeo/tag.py
+++ b/aiocogeo/tag.py
@@ -74,7 +74,7 @@ class Tag:
             reader.incr(4 - length)
 
             if name == "NewSubfileType":
-                bit32 = '{:032b}'.format(value[0])
+                bit32 = "{:032b}".format(value[0])
                 value = [[int(x) for x in str(int(bit32)).zfill(3)]]
 
         else:


### PR DESCRIPTION
- Adds config option `HTTP_MERGE_CONSECUTIVE_RANGES` to merge consecutive range requests into single requests to match the [GDAL config option](https://trac.osgeo.org/gdal/wiki/ConfigOptions#GDAL_HTTP_MERGE_CONSECUTIVE_RANGES).
- This PR won't address caching, since I'm still not sure the best way of doing it, so I've opened #30 to track that.

TODOs:
- [ ] Merge range requests for internal mask.
- [ ] More test cases.

Closes #23 