### PR TITLE
refactor partial read

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/naip_i
 Configuration options are exposed through environment variables:
 - **INGESTED_BYTES_AT_OPEN** - defines the number of bytes in the first GET request at file opening (defaults to 16KB)
 - **ENABLE_BLOCK_CACHE** - determines if internal blocks are cached in memory (defaults to TRUE)
+- **HTTP_MERGE_CONSECUTIVE_RANGES** - determines if consecutive ranges are merged into a single request (defaults to FALSE)
+>>>>>>> update readme
 
+Refer to [`aiocogeo/config.py`](https://github.com/geospatial-jeff/aiocogeo/blob/master/aiocogeo/config.py) for more details about configuration options.
 
 ## CLI
 ```

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Configuration options are exposed through environment variables:
 - **INGESTED_BYTES_AT_OPEN** - defines the number of bytes in the first GET request at file opening (defaults to 16KB)
 - **ENABLE_BLOCK_CACHE** - determines if internal blocks are cached in memory (defaults to TRUE)
 - **HTTP_MERGE_CONSECUTIVE_RANGES** - determines if consecutive ranges are merged into a single request (defaults to FALSE)
->>>>>>> update readme
 
 Refer to [`aiocogeo/config.py`](https://github.com/geospatial-jeff/aiocogeo/blob/master/aiocogeo/config.py) for more details about configuration options.
 

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -200,8 +200,7 @@ class COGReader(PartialRead):
         )
 
         # Request those tiles
-        img_arr = self._init_array(img_tiles)
-        await self._request_tiles(img_arr, img_tiles)
+        img_arr = await self._request_tiles(img_tiles)
 
         # Clip the array to the request bounds
         clipped = self._clip_array(img_arr, img_tiles)

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -13,7 +13,7 @@ from .constants import PHOTOMETRIC
 from .errors import InvalidTiffError, TileNotFoundError
 from .filesystems import Filesystem
 from .ifd import IFD, ImageIFD, MaskIFD
-from .partial_reads import PartialRead
+from .partial_reads import PartialReadInterface
 
 
 def config_cache(fn: Callable) -> Callable:
@@ -26,7 +26,7 @@ def config_cache(fn: Callable) -> Callable:
     return wrap_function
 
 @dataclass
-class COGReader(PartialRead):
+class COGReader(PartialReadInterface):
     filepath: str
     ifds: Optional[List[ImageIFD]] = field(default_factory=lambda: [])
     mask_ifds: Optional[List[MaskIFD]] = field(default_factory=lambda: [])

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -202,13 +202,10 @@ class COGReader(PartialRead):
         # Request those tiles
         img_arr = await self._request_tiles(img_tiles)
 
-        # Clip the array to the request bounds
-        clipped = self._clip_array(img_arr, img_tiles)
+        # Postprocess the array (clip to bounds and resize to requested shape)
+        postprocessed = self._postprocess(img_arr, img_tiles, shape)
 
-        # Resample to match requested shape
-        resized = self._resample(clipped, img_tiles, shape)
-
-        return resized
+        return postprocessed
 
     def create_tile_matrix_set(self, identifier: str = None) -> Dict[str, Any]:
         """Create an OGC TileMatrixSet where each TileMatrix corresponds to an overview"""

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -200,7 +200,10 @@ class COGReader(PartialReadInterface):
         )
 
         # Request those tiles
-        img_arr = await self._request_tiles(img_tiles)
+        if config.HTTP_MERGE_CONSECUTIVE_RANGES == "TRUE":
+            img_arr = await self._request_merged_tiles(img_tiles)
+        else:
+            img_arr = await self._request_tiles(img_tiles)
 
         # Postprocess the array (clip to bounds and resize to requested shape)
         postprocessed = self._postprocess(img_arr, img_tiles, shape)

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -201,7 +201,7 @@ class COGReader(PartialReadInterface):
         )
 
         # Request those tiles
-        if config.HTTP_MERGE_CONSECUTIVE_RANGES == "TRUE":
+        if config.HTTP_MERGE_CONSECUTIVE_RANGES:
             img_arr = await self._request_merged_tiles(img_tiles)
         else:
             img_arr = await self._request_tiles(img_tiles)

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -145,6 +145,7 @@ class COGReader(PartialReadInterface):
             )
         return gt
 
+    @config_cache
     @cached(
         cache=Cache.MEMORY,
         key_builder=lambda fn,*args,**kwargs: f"{args[0].filepath}-{args[1]}-{args[2]}-{args[3]}"

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -1,10 +1,8 @@
 """Configurable values exposed to user as environment variables"""
 import os
 
-import logging
-
 # Changes the log level
-LOG_LEVEL: str = os.getenv("LOG_LEVEL", "WARN")
+LOG_LEVEL: str = os.getenv("LOG_LEVEL", "ERROR")
 
 # https://gdal.org/user/virtual_file_systems.html#vsicurl-http-https-ftp-files-random-access
 # Defines the number of bytes read in the first GET request at file opening
@@ -12,3 +10,10 @@ LOG_LEVEL: str = os.getenv("LOG_LEVEL", "WARN")
 INGESTED_BYTES_AT_OPEN: int = os.getenv("INGESTED_BYTES_AT_OPEN", 16384)
 
 ENABLE_BLOCK_CACHE: bool = True if os.getenv("ENABLE_BLOCK_CACHE", "TRUE").upper() == "TRUE" else False
+
+# https://trac.osgeo.org/gdal/wiki/ConfigOptions#GDAL_HTTP_MERGE_CONSECUTIVE_RANGES
+# Determines if consecutive range requests are merged into a single request, reducing the number of HTTP GET range
+# requests required to read consecutive internal image tiles
+HTTP_MERGE_CONSECUTIVE_RANGES: str = os.getenv(
+    "HTTP_MERGE_CONSECUTIVE_RANGES", "FALSE"
+).upper()

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -9,11 +9,15 @@ LOG_LEVEL: str = os.getenv("LOG_LEVEL", "ERROR")
 # Can help performance when reading images with a large header
 INGESTED_BYTES_AT_OPEN: int = os.getenv("INGESTED_BYTES_AT_OPEN", 16384)
 
-ENABLE_BLOCK_CACHE: bool = True if os.getenv("ENABLE_BLOCK_CACHE", "TRUE").upper() == "TRUE" else False
+# https://trac.osgeo.org/gdal/wiki/ConfigOptions#VSI_CACHE
+# Determines if in-memory block caching is enabled
+ENABLE_BLOCK_CACHE: bool = True if os.getenv(
+    "ENABLE_BLOCK_CACHE", "TRUE"
+).upper() == "TRUE" else False
 
 # https://trac.osgeo.org/gdal/wiki/ConfigOptions#GDAL_HTTP_MERGE_CONSECUTIVE_RANGES
 # Determines if consecutive range requests are merged into a single request, reducing the number of HTTP GET range
 # requests required to read consecutive internal image tiles
-HTTP_MERGE_CONSECUTIVE_RANGES: str = os.getenv(
+HTTP_MERGE_CONSECUTIVE_RANGES: bool = True if os.getenv(
     "HTTP_MERGE_CONSECUTIVE_RANGES", "FALSE"
-).upper()
+).upper() == "TRUE" else False

--- a/aiocogeo/partial_reads.py
+++ b/aiocogeo/partial_reads.py
@@ -263,7 +263,7 @@ class PartialReadBase(abc.ABC):
                 clipped.mask,
                 output_shape=(img_tiles.bands, out_shape[0], out_shape[1]),
                 preserve_range=True,
-                anti_aliasing=True,
+                anti_aliasing=False,
                 order=0,
             )
             resized = np.ma.masked_array(resized, resized_mask)

--- a/aiocogeo/partial_reads.py
+++ b/aiocogeo/partial_reads.py
@@ -61,6 +61,11 @@ class PartialRead(abc.ABC):
         """Request an internal image tile at the specified row (x), column (y), and overview (z)"""
         ...
 
+    @abc.abstractmethod
+    async def read(self, bounds: Tuple[float, float, float, float], shape: Tuple[int, int]) -> Union[np.ndarray, np.ma.masked_array]:
+        """Do a partial read"""
+        ...
+
     def _get_overview_level(
         self, bounds: Tuple[float, float, float, float], width: int, height: int
     ) -> int:

--- a/aiocogeo/partial_reads.py
+++ b/aiocogeo/partial_reads.py
@@ -243,3 +243,11 @@ class PartialRead(abc.ABC):
             )
             resized = np.ma.masked_array(resized, resized_mask)
         return resized
+
+    async def _postprocess(self, arr: NpArrayType, img_tiles: ReadMetadata, out_shape: Tuple[int, int]) -> NpArrayType:
+        """Wrapper around ``_clip_array`` and ``_resample`` to postprocess the partial read"""
+        return self._resample(
+            self._clip_array(arr, img_tiles),
+            img_tiles=img_tiles,
+            out_shape=out_shape
+        )

--- a/aiocogeo/partial_reads.py
+++ b/aiocogeo/partial_reads.py
@@ -1,0 +1,238 @@
+"""COG mixins for partial reads"""
+import asyncio
+import abc
+from dataclasses import dataclass
+from functools import partial
+import math
+from typing import List, Tuple, Union
+
+import affine
+import numpy as np
+from skimage.transform import resize
+
+NpArrayType = Union[np.ndarray, np.ma.masked_array]
+
+
+@dataclass
+class ReadMetadata:
+    # top left corner of the partial read
+    tlx: float
+    tly: float
+    # width and height of the partial read (# of pixels)
+    width: int
+    height: int
+    # width and height of each block (# of pixels)
+    tile_width: int
+    tile_height: int
+    # range of internal x/y blocks which intersect the partial read
+    xmin: int
+    ymin: int
+    xmax: int
+    ymax: int
+    # expected number of bands
+    bands: int
+    # numpy data type
+    dtype: np.dtype
+    # overview level (where 0 is source)
+    ovr_level: int
+
+
+@dataclass
+class PartialRead(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def is_masked(self) -> bool:
+        """Check if the image has an internal mask"""
+        ...
+
+    @property
+    @abc.abstractmethod
+    def overviews(self) -> List[int]:
+        """Return decimation factor for each overview (2**zoom)"""
+        ...
+
+    @abc.abstractmethod
+    def geotransform(self, ovr_level: int = 0) -> affine.Affine:
+        """Return the geotransform of the image at a specific overview level (defaults to native resolution)"""
+        ...
+
+    @abc.abstractmethod
+    async def get_tile(self, x: int, y: int, z: int) -> NpArrayType:
+        """Request an internal image tile at the specified row (x), column (y), and overview (z)"""
+        ...
+
+    def _get_overview_level(
+        self, bounds: Tuple[float, float, float, float], width: int, height: int
+    ) -> int:
+        """
+        Calculate appropriate overview level given request bounds and shape (width + height).  Based on rio-tiler:
+        https://github.com/cogeotiff/rio-tiler/blob/v2/rio_tiler/utils.py#L79-L135
+        """
+        src_res = self.geotransform().a
+        target_gt = affine.Affine.translation(
+            bounds[0], bounds[3]
+        ) * affine.Affine.scale(
+            (bounds[2] - bounds[0]) / width, (bounds[1] - bounds[3]) / height
+        )
+        target_res = target_gt.a
+
+        ovr_level = 0
+        if target_res > src_res:
+            # Decimated resolution at each overview
+            overviews = [src_res * decim for decim in self.overviews]
+            for ovr_level in range(ovr_level, len(overviews) - 1):
+                ovr_res = src_res if ovr_level == 0 else overviews[ovr_level]
+                if (ovr_res < target_res) and (overviews[ovr_level + 1] > target_res):
+                    break
+                if abs(ovr_res - target_res) < 1e-1:
+                    break
+            else:
+                ovr_level = len(overviews) - 1
+
+        return ovr_level
+
+    def _calculate_image_tiles(
+        self,
+        bounds: Tuple[float, float, float, float],
+        tile_width: int,
+        tile_height: int,
+        band_count: int,
+        ovr_level: int,
+        dtype: np.dtype,
+    ) -> ReadMetadata:
+        """
+        Internal method to calculate which images tiles need to be requested for a partial read.  Also returns all of
+        the required metadata about the image tiles to perform a partial read
+        """
+        geotransform = self.geotransform(ovr_level)
+        invgt = ~geotransform
+
+        # Project request bounds to pixel coordinates relative to geotransform of the overview
+        tlx, tly = invgt * (bounds[0], bounds[3])
+        brx, bry = invgt * (bounds[2], bounds[1])
+
+        # Calculate tiles
+        xmin = math.floor((tlx + 1e-6) / tile_width)
+        xmax = math.floor((brx + 1e-6) / tile_width)
+        ymax = math.floor((bry + 1e-6) / tile_height)
+        ymin = math.floor((tly + 1e-6) / tile_height)
+
+        tile_bounds = (
+            xmin * tile_width,
+            ymin * tile_height,
+            (xmax + 1) * tile_width,
+            (ymax + 1) * tile_height,
+        )
+
+        # Create geotransform for the fused image
+        _tlx, _tly = geotransform * (tile_bounds[0], tile_bounds[1])
+        fused_gt = affine.Affine(
+            geotransform.a, geotransform.b, _tlx, geotransform.d, geotransform.e, _tly
+        )
+        inv_fused_gt = ~fused_gt
+        xorigin, yorigin = [round(v) for v in inv_fused_gt * (bounds[0], bounds[3])]
+
+        return ReadMetadata(
+            tlx=xorigin,
+            tly=yorigin,
+            width=round(brx - tlx),
+            height=round(bry - tly),
+            xmin=xmin,
+            ymin=ymin,
+            xmax=xmax,
+            ymax=ymax,
+            tile_width=tile_width,
+            tile_height=tile_height,
+            bands=band_count,
+            dtype=dtype,
+            ovr_level=ovr_level,
+        )
+
+    def _init_array(self, img_tiles: ReadMetadata) -> NpArrayType:
+        """
+        Initialize an empty numpy array with the same shape of the partial read.  Individual blocks are mosaiced into
+        this array as they are requested
+        """
+        fused = np.zeros(
+            (
+                img_tiles.bands,
+                (img_tiles.ymax + 1 - img_tiles.ymin) * img_tiles.tile_height,
+                (img_tiles.xmax + 1 - img_tiles.xmin) * img_tiles.tile_width,
+            )
+        ).astype(img_tiles.dtype)
+        if self.is_masked:
+            fused = np.ma.masked_array(fused)
+        return fused
+
+    @staticmethod
+    def _stitch_image_tile(
+        fut: asyncio.Future,
+        fused_arr: NpArrayType,
+        idx: int,
+        idy: int,
+        tile_width: int,
+        tile_height: int,
+    ) -> None:
+        """Internal asyncio callback used to mosaic each image tile into a larger array (see ``_init_array``)"""
+        img_arr = fut.result()
+        fused_arr[
+            :,
+            idy * tile_height : (idy + 1) * tile_height,
+            idx * tile_width : (idx + 1) * tile_width,
+        ] = img_arr
+        if np.ma.is_masked(img_arr):
+            fused_arr.mask[
+                :,
+                idy * tile_height : (idy + 1) * tile_height,
+                idx * tile_width : (idx + 1) * tile_width,
+            ] = img_arr.mask
+
+    async def _request_tiles(self, arr: NpArrayType, img_tiles: ReadMetadata) -> None:
+        """Concurrently request the image tiles and mosaic into a larger array"""
+        tile_tasks = []
+        for idx, xtile in enumerate(range(img_tiles.xmin, img_tiles.xmax + 1)):
+            for idy, ytile in enumerate(range(img_tiles.ymin, img_tiles.ymax + 1)):
+                get_tile_task = asyncio.create_task(
+                    self.get_tile(xtile, ytile, img_tiles.ovr_level)
+                )
+                get_tile_task.add_done_callback(
+                    partial(
+                        self._stitch_image_tile,
+                        fused_arr=arr,
+                        idx=idx,
+                        idy=idy,
+                        tile_width=img_tiles.tile_width,
+                        tile_height=img_tiles.tile_height,
+                    )
+                )
+                tile_tasks.append(get_tile_task)
+        await asyncio.gather(*tile_tasks)
+
+    def _clip_array(self, arr: NpArrayType, img_tiles: ReadMetadata) -> NpArrayType:
+        """Clip a numpy array to the extent of the parial read via slicing"""
+        return arr[
+            :,
+            img_tiles.tly : img_tiles.tly + img_tiles.height,
+            img_tiles.tlx : img_tiles.tlx + img_tiles.width,
+        ]
+
+    def _resample(
+        self, clipped: NpArrayType, img_tiles: ReadMetadata, out_shape: Tuple[int, int]
+    ) -> NpArrayType:
+        """Resample a numpy array to the desired shape"""
+        resized = resize(
+            clipped,
+            output_shape=(img_tiles.bands, out_shape[0], out_shape[1]),
+            preserve_range=True,
+            anti_aliasing=True,
+        ).astype(img_tiles.dtype)
+        if self.is_masked:
+            resized_mask = resize(
+                clipped.mask,
+                output_shape=(img_tiles.bands, out_shape[0], out_shape[1]),
+                preserve_range=True,
+                anti_aliasing=True,
+                order=0,
+            )
+            resized = np.ma.masked_array(resized, resized_mask)
+        return resized

--- a/aiocogeo/partial_reads.py
+++ b/aiocogeo/partial_reads.py
@@ -38,7 +38,7 @@ class ReadMetadata:
 
 
 @dataclass
-class PartialRead(abc.ABC):
+class PartialReadInterface(abc.ABC):
     @property
     @abc.abstractmethod
     def is_masked(self) -> bool:

--- a/aiocogeo/partial_reads.py
+++ b/aiocogeo/partial_reads.py
@@ -244,7 +244,7 @@ class PartialRead(abc.ABC):
             resized = np.ma.masked_array(resized, resized_mask)
         return resized
 
-    async def _postprocess(self, arr: NpArrayType, img_tiles: ReadMetadata, out_shape: Tuple[int, int]) -> NpArrayType:
+    def _postprocess(self, arr: NpArrayType, img_tiles: ReadMetadata, out_shape: Tuple[int, int]) -> NpArrayType:
         """Wrapper around ``_clip_array`` and ``_resample`` to postprocess the partial read"""
         return self._resample(
             self._clip_array(arr, img_tiles),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import aiohttp
 import pytest
 from typer.testing import CliRunner
 
+from aiocogeo import config
 from aiocogeo import COGReader
 
 
@@ -29,7 +30,8 @@ async def client_session():
 
 
 @pytest.fixture
-def create_cog_reader(client_session):
+def create_cog_reader(client_session, monkeypatch):
+    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", False)
     def _create_reader(infile):
         return COGReader(filepath=infile)
 

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -222,6 +222,8 @@ async def test_cog_read_merge_range_requests(create_cog_reader, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_cog_read_merge_range_requests_with_internal_nodata_mask(create_cog_reader, monkeypatch):
+    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", False)
+
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/naip_image_masked.tif"
     bounds = (-10526706.9, 4445561.5, -10526084.1, 4446144.0)
     shape = (512, 512)
@@ -283,8 +285,9 @@ async def test_cog_metadata_iter(infile, create_cog_reader):
                 assert isinstance(tag, Tag)
 
 @pytest.mark.asyncio
-async def test_block_cache_enabled(create_cog_reader):
-    # Cache is enabled by default
+async def test_block_cache_enabled(create_cog_reader, monkeypatch):
+    # Cache is disabled for tests
+    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", True)
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
     async with create_cog_reader(infile) as cog:
         await cog.get_tile(0,0,0)
@@ -295,8 +298,7 @@ async def test_block_cache_enabled(create_cog_reader):
 
 
 @pytest.mark.asyncio
-async def test_block_cache_disabled(create_cog_reader, monkeypatch):
-    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", False)
+async def test_block_cache_disabled(create_cog_reader):
 
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
     async with create_cog_reader(infile) as cog:

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -207,7 +207,7 @@ async def test_cog_read_merge_range_requests(create_cog_reader, monkeypatch):
         bytes_requested = cog._file_reader._total_bytes_requested
 
     # Do a request with merged range requests
-    monkeypatch.setattr(config, "HTTP_MERGE_CONSECUTIVE_RANGES", "TRUE")
+    monkeypatch.setattr(config, "HTTP_MERGE_CONSECUTIVE_RANGES", True)
     async with create_cog_reader(infile) as cog:
         tile_data_merged = await cog.read(bounds=bounds, shape=shape)
         merged_request_count = cog._file_reader._total_requests
@@ -222,8 +222,6 @@ async def test_cog_read_merge_range_requests(create_cog_reader, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_cog_read_merge_range_requests_with_internal_nodata_mask(create_cog_reader, monkeypatch):
-    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", False)
-
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/naip_image_masked.tif"
     bounds = (-10526706.9, 4445561.5, -10526084.1, 4446144.0)
     shape = (512, 512)
@@ -236,7 +234,7 @@ async def test_cog_read_merge_range_requests_with_internal_nodata_mask(create_co
         bytes_requested = cog._file_reader._total_bytes_requested
 
     # Do a request with merged range requests
-    monkeypatch.setattr(config, "HTTP_MERGE_CONSECUTIVE_RANGES", "TRUE")
+    monkeypatch.setattr(config, "HTTP_MERGE_CONSECUTIVE_RANGES", True)
     async with create_cog_reader(infile) as cog:
         tile_data_merged = await cog.read(bounds=bounds, shape=shape)
         # assert np.ma.is_masked(tile_data_merged)

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -122,20 +122,31 @@ async def test_cog_calculate_image_tiles(infile, create_cog_reader):
     async with create_cog_reader(infile) as cog:
         ovr_level = 0
         gt = cog.geotransform(ovr_level)
+        ifd = cog.ifds[ovr_level]
 
         # Find bounds of top left tile at native res
         bounds = (
             gt.c,
-            gt.f + cog.ifds[0].TileHeight.value * gt.e,
-            gt.c + cog.ifds[0].TileWidth.value * gt.a,
+            gt.f + ifd.TileHeight.value * gt.e,
+            gt.c + ifd.TileWidth.value * gt.a,
             gt.f
         )
 
-        img_tile = cog._calculate_image_tiles(bounds, ovr_level)
-        assert img_tile['tlx'] == img_tile['tly'] == 0
-        assert img_tile['width'] == cog.ifds[0].TileWidth.value
-        assert img_tile['height'] == cog.ifds[0].TileHeight.value
-        assert img_tile['tile_ranges'] == (0, 0, 1, 1)
+        img_tile = cog._calculate_image_tiles(
+            bounds,
+            tile_width=ifd.TileWidth.value,
+            tile_height=ifd.TileHeight.value,
+            band_count=ifd.bands,
+            ovr_level=ovr_level,
+            dtype=ifd.dtype
+        )
+        assert img_tile.tlx == img_tile.tly == 0
+        assert img_tile.width == cog.ifds[0].TileWidth.value
+        assert img_tile.height == cog.ifds[0].TileHeight.value
+        assert img_tile.xmin == 0
+        assert img_tile.ymin == 0
+        assert img_tile.xmax == 1
+        assert img_tile.ymax == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -191,7 +191,7 @@ async def test_cog_read_internal_mask(create_cog_reader):
         # Confirm proportion of masked pixels
         valid_data = tile[tile.mask == False]
         frequencies = np.asarray(np.unique(valid_data, return_counts=True)).T
-        assert pytest.approx(frequencies[0][1] / np.prod(tile.shape), abs=0.004) == 0
+        assert pytest.approx(frequencies[0][1] / np.prod(tile.shape), abs=0.002) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Rename `IFD` to `ImageIFD`.  Add `MaskIFD` class (subclass of `ImageIFD`).  For example:
- Moves methods required for partial reading from `COGReader` to the `PartialRead` mixin.  This has several advantages:
    - `PartialRead` is totally abstracted from the library (no dependency on `IFD`, `Tag` etc.).  Any client which implements the interface defined by the mixin can do partial reads.  This makes it easier for clients to extend the library and to build internal interfaces for doing different types of partial reads (ex. merged range requests).
    - cpu bound code is more self contained, making it easier to run in a threadpool.
    - Partial read requires a lot of semi-private methods, removing them from `COGReader` makes the code easier to read.
- Add config option to merge consecutive range requests (started in #29).

Closes #33 