### PR TITLE
Debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Configuration options are exposed through environment variables:
 - **INGESTED_BYTES_AT_OPEN** - defines the number of bytes in the first GET request at file opening (defaults to 16KB)
 - **ENABLE_BLOCK_CACHE** - determines if internal blocks are cached in memory (defaults to TRUE)
 - **HTTP_MERGE_CONSECUTIVE_RANGES** - determines if consecutive ranges are merged into a single request (defaults to FALSE)
+- **LOG_LEVEL** - determines the log level used by the package (defaults to ERROR)
+- **VERBOSE_LOGS** - enables verbose logging, designed for use when `LOG_LEVEL=DEBUG` (defaults to FALSE)
 
 Refer to [`aiocogeo/config.py`](https://github.com/geospatial-jeff/aiocogeo/blob/master/aiocogeo/config.py) for more details about configuration options.
 

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import dataclass, field
+import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin
 import uuid
@@ -15,6 +16,8 @@ from .filesystems import Filesystem
 from .ifd import IFD, ImageIFD, MaskIFD
 from .partial_reads import PartialReadInterface
 
+logger = logging.getLogger(__name__)
+logger.setLevel(config.LOG_LEVEL)
 
 def config_cache(fn: Callable) -> Callable:
     """
@@ -115,6 +118,7 @@ class COGReader(PartialReadInterface):
         next_ifd_offset = 1
         while next_ifd_offset != 0:
             ifd = await IFD.read(self._file_reader)
+            logger.debug(f" Opened {ifd.ImageHeight.value}x{ifd.ImageWidth.value} overview")
             next_ifd_offset = ifd.next_ifd_offset
             self._file_reader.seek(next_ifd_offset)
 

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -109,6 +109,15 @@ class COGReader(PartialReadInterface):
         return [2 ** (ifd + 1) for ifd in range(len(self.ifds) - 1)]
 
     @property
+    def requests(self) -> Dict[str, Union[int, List[Tuple[int]]]]:
+        """Return statistics about http requests made during context lifecycle"""
+        return {
+            'count': self._file_reader._total_requests,
+            'byte_count': self._file_reader._total_bytes_requested,
+            'ranges': self._file_reader._requested_ranges
+        }
+
+    @property
     def is_masked(self) -> bool:
         """Check if the image has an internal mask"""
         return True if self.mask_ifds else False

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -7,7 +7,7 @@ LOG_LEVEL: str = os.getenv("LOG_LEVEL", "ERROR")
 
 logging.basicConfig(level=LOG_LEVEL)
 
-# Enables verbose logging
+# Enables verbose logging.  It is recommended to also use ``LOG_LEVEL=DEBUG``.
 VERBOSE_LOGS: bool = False if os.getenv("VERBOSE_LOGS", "FALSE") == "FALSE" else True
 
 # https://gdal.org/user/virtual_file_systems.html#vsicurl-http-https-ftp-files-random-access

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -1,8 +1,14 @@
 """Configurable values exposed to user as environment variables"""
+import logging
 import os
 
 # Changes the log level
 LOG_LEVEL: str = os.getenv("LOG_LEVEL", "ERROR")
+
+logging.basicConfig(level=LOG_LEVEL)
+
+# Enables verbose logging
+VERBOSE_LOGS: bool = False if os.getenv("VERBOSE_LOGS", "FALSE") == "FALSE" else True
 
 # https://gdal.org/user/virtual_file_systems.html#vsicurl-http-https-ftp-files-random-access
 # Defines the number of bytes read in the first GET request at file opening

--- a/aiocogeo/filesystems.py
+++ b/aiocogeo/filesystems.py
@@ -138,11 +138,15 @@ class HttpFilesystem(Filesystem):
 class LocalFilesystem(Filesystem):
 
     async def range_request(self, start: int, offset: int) -> bytes:
+        begin = time.time()
         await self.file.seek(start)
+        data = await self.file.read(offset+1)
+        elapsed = time.time() - begin
         self._total_bytes_requested += (offset - start + 1)
         self._total_requests += 1
         self._requested_ranges.append((start, start+offset))
-        return await self.file.read(offset+1)
+        logger.debug(f" FINISHED REQUEST in {elapsed} seconds: <STATUS 206> ({start}-{start+offset})")
+        return data
 
     async def _close(self) -> None:
         await self.file.close()

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -203,15 +203,15 @@ async def test_cog_read_merge_range_requests(create_cog_reader, monkeypatch):
     # Do a request without merged range requests
     async with create_cog_reader(infile) as cog:
         tile_data = await cog.read(bounds=bounds, shape=shape)
-        request_count = cog._file_reader._total_requests
-        bytes_requested = cog._file_reader._total_bytes_requested
+        request_count = cog.requests['count']
+        bytes_requested = cog.requests['byte_count']
 
     # Do a request with merged range requests
     monkeypatch.setattr(config, "HTTP_MERGE_CONSECUTIVE_RANGES", True)
     async with create_cog_reader(infile) as cog:
         tile_data_merged = await cog.read(bounds=bounds, shape=shape)
-        merged_request_count = cog._file_reader._total_requests
-        merged_bytes_requested = cog._file_reader._total_bytes_requested
+        merged_request_count = cog.requests['count']
+        merged_bytes_requested = cog.requests['byte_count']
 
     # Confirm we got the same tile with fewer requests
     assert merged_request_count < request_count
@@ -230,16 +230,16 @@ async def test_cog_read_merge_range_requests_with_internal_nodata_mask(create_co
     async with create_cog_reader(infile) as cog:
         tile_data = await cog.read(bounds=bounds, shape=shape)
         # assert np.ma.is_masked(tile_data)
-        request_count = cog._file_reader._total_requests
-        bytes_requested = cog._file_reader._total_bytes_requested
+        request_count = cog.requests['count']
+        bytes_requested = cog.requests['byte_count']
 
     # Do a request with merged range requests
     monkeypatch.setattr(config, "HTTP_MERGE_CONSECUTIVE_RANGES", True)
     async with create_cog_reader(infile) as cog:
         tile_data_merged = await cog.read(bounds=bounds, shape=shape)
         # assert np.ma.is_masked(tile_data_merged)
-        merged_request_count = cog._file_reader._total_requests
-        merged_bytes_requested = cog._file_reader._total_bytes_requested
+        merged_request_count = cog.requests['count']
+        merged_bytes_requested = cog.requests['byte_count']
 
     # Confirm we got the same tile with fewer requests
     assert merged_request_count < request_count
@@ -289,10 +289,10 @@ async def test_block_cache_enabled(create_cog_reader, monkeypatch):
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
     async with create_cog_reader(infile) as cog:
         await cog.get_tile(0,0,0)
-        request_count = cog._file_reader._total_requests
+        request_count = cog.requests['count']
 
         await cog.get_tile(0,0,0)
-        assert cog._file_reader._total_requests == request_count
+        assert cog.requests['count'] == request_count
 
 
 @pytest.mark.asyncio
@@ -301,10 +301,10 @@ async def test_block_cache_disabled(create_cog_reader):
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
     async with create_cog_reader(infile) as cog:
         await cog.get_tile(0,0,0)
-        request_count = cog._file_reader._total_requests
+        request_count = cog.requests['count']
 
         await cog.get_tile(0,0,0)
-        assert cog._file_reader._total_requests == request_count + 1
+        assert cog.requests['count'] == request_count + 1
 
 
 

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -307,8 +307,8 @@ async def test_block_cache_disabled(create_cog_reader):
 
 
 @pytest.mark.asyncio
-async def test_cog_request_metadata(create_cog_reader):
-    infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
+@pytest.mark.parametrize("infile", TEST_DATA)
+async def test_cog_request_metadata(create_cog_reader, infile):
     async with create_cog_reader(infile) as cog:
         request_metadata = cog.requests
 

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -297,7 +297,6 @@ async def test_block_cache_enabled(create_cog_reader, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_block_cache_disabled(create_cog_reader):
-
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
     async with create_cog_reader(infile) as cog:
         await cog.get_tile(0,0,0)
@@ -306,6 +305,15 @@ async def test_block_cache_disabled(create_cog_reader):
         await cog.get_tile(0,0,0)
         assert cog.requests['count'] == request_count + 1
 
+
+@pytest.mark.asyncio
+async def test_cog_request_metadata(create_cog_reader):
+    infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
+    async with create_cog_reader(infile) as cog:
+        request_metadata = cog.requests
+
+    assert len(request_metadata['ranges']) == request_metadata['count']
+    assert sum([end-start+1 for (start,end) in request_metadata['ranges']]) == request_metadata['byte_count']
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Adds debug logs for range requests.
- Adds `VERBOSE_LOGS` config to enable more detailed logging for each request (defaults to FALSE)
    - For `http`, aiohttp client trace is used to create our own logs.
    - For `s3`, the default `aioboto3`, `aiobotocore`, and `botocore` loggers are used, log level is set to value defined by `LOG_LEVEL` config.
    - For `file`, does not cause any additional logging. 
- Log statements intentionally look similar to GDAL logs when [`CPL_DEBUG`](https://trac.osgeo.org/gdal/wiki/ConfigOptions#CPL_DEBUG) and [`CPL_CURL_VERBOSE`](https://trac.osgeo.org/gdal/wiki/ConfigOptions#CPL_CURL_VERBOSE) are enabled.

### TODOs:
- [x] Add similar logging for `s3://` and `file`


Closes #22 

### Example
```python
async with COGReader("http://cog.tif") as cog:
    print(cog.requests)

{
  "count": <request_count>,
  "byte_count": <total_bytes_requested>,
  "ranges": [
      (start1, end1),
      (start2, end2),
      ...
  ]
}
```

#### CLI
```
> LOG_LEVEL=DEBUG VERBOSE_LOGS=TRUE aiocogeo info https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif
```

```
DEBUG:asyncio:Using selector: KqueueSelector
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=0-16384
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: pgJJTBsoBIu4k+1R3CEJumvubxC0nhzXVkFFy3GKbo0pWNgIaBa0CRkAudQn5bGcvOpjHbrbT7k=
 < x-amz-request-id: F93E678715118417
 < Date: Sun, 31 May 2020 20:37:35 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 0-16384/541425806
 < Content-Type: image/tiff
 < Content-Length: 16385
 < Server: AmazonS3
 < Duration: 0.161
WARNING:aiocogeo.tag:TIFF TAG 270 is not supported.
WARNING:aiocogeo.tag:TIFF TAG 282 is not supported.
WARNING:aiocogeo.tag:TIFF TAG 283 is not supported.
WARNING:aiocogeo.tag:TIFF TAG 296 is not supported.
WARNING:aiocogeo.tag:TIFF TAG 305 is not supported.
WARNING:aiocogeo.tag:TIFF TAG 34736 is not supported.
WARNING:aiocogeo.tag:TIFF TAG 34737 is not supported.
WARNING:aiocogeo.tag:TIFF TAG 42112 is not supported.
DEBUG:aiocogeo.cog: Opened 12190x10280 overview
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=12726-20597
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: C8d43xjpoqkMXiYZ7bVovtkqA9AZAgEE/NP7lipIvaao/YPhPcyRU7KIINyev/q3eB0BgHz5nwI=
 < x-amz-request-id: 3117141A09930670
 < Date: Sun, 31 May 2020 20:37:35 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 12726-20597/541425806
 < Content-Type: image/tiff
 < Content-Length: 7872
 < Server: AmazonS3
 < Duration: 0.043
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=20598-20603
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: asBkvj8ywE2yvZxvF0S2PaKKVh7USvYnPicUnvL8bSBTnhwpIn8OmWzxNz5Gcex7jl93sOch6u0=
 < x-amz-request-id: 47BF64D077B1D522
 < Date: Sun, 31 May 2020 20:37:35 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 20598-20603/541425806
 < Content-Type: image/tiff
 < Content-Length: 6
 < Server: AmazonS3
 < Duration: 0.067
DEBUG:aiocogeo.cog: Opened 6095x5140 overview
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=16385-32769
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: Ce5i46thARpJAxL9osCJJwPoSPjPpnOH71aUE5TClWrAaAhWtzLd1SSpHABWcnmNHFWgcXxXPVw=
 < x-amz-request-id: 365F8400397A924E
 < Date: Sun, 31 May 2020 20:37:35 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 16385-32769/541425806
 < Content-Type: image/tiff
 < Content-Length: 16385
 < Server: AmazonS3
 < Duration: 0.041
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=20778-20783
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: XoiTaONluw1JGqmmNL94uBi/GHQj4v+9ObWBqdMml1YLyX7y9lCYieqBLlaTLMomRRcCqq0Eq00=
 < x-amz-request-id: C044F003EA2D5410
 < Date: Sun, 31 May 2020 20:37:35 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 20778-20783/541425806
 < Content-Type: image/tiff
 < Content-Length: 6
 < Server: AmazonS3
 < Duration: 0.037
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=22800-24815
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: 9wISvLm/6okhqdqYGk+kGoDpruXe1pebfbf0b8Z218J6AVLtMngujMc58sZBYTfr1YFZwcws9Ns=
 < x-amz-request-id: E8D80B47F06C0B45
 < Date: Sun, 31 May 2020 20:37:35 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 22800-24815/541425806
 < Content-Type: image/tiff
 < Content-Length: 2016
 < Server: AmazonS3
 < Duration: 0.042
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=20784-22799
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: zSBIpYvJTQxgGfwfqN+b5Cv/ZC60qB4VPYr+xCf/SuUR2AJyPN5f1Sgf76oy5makmNHzxYId/r4=
 < x-amz-request-id: A1C2FA308B01CCA2
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 20784-22799/541425806
 < Content-Type: image/tiff
 < Content-Length: 2016
 < Server: AmazonS3
 < Duration: 0.044
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=24816-24821
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: ZNzCTflraym29SmFT/xZW36BsTV/L2tMORFNmP0Wgv/NXTH+y65MnujTiKejOapnGGs+V9KQroU=
 < x-amz-request-id: B82D4909081DD6DA
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 24816-24821/541425806
 < Content-Type: image/tiff
 < Content-Length: 6
 < Server: AmazonS3
 < Duration: 0.038
DEBUG:aiocogeo.cog: Opened 3048x2570 overview
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=24996-25001
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: Ufm1rjpJcePIMFOL9TioBC9h0/rxxQ/pw1c91FVKD/uiGPHa5XzPlq5nXLMrdcDkKFjqmQSBqPY=
 < x-amz-request-id: 6D6A3D8C7811E8EF
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 24996-25001/541425806
 < Content-Type: image/tiff
 < Content-Length: 6
 < Server: AmazonS3
 < Duration: 0.039
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=25530-26057
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: VUTNuuI8+QJEBNzHYiGmuxzcFZETZr2en8uG/4ZOqFw1cYcI+++0W5s53wq8megitArHwy1wqB4=
 < x-amz-request-id: C6B531101506393F
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 25530-26057/541425806
 < Content-Type: image/tiff
 < Content-Length: 528
 < Server: AmazonS3
 < Duration: 0.039
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=25002-25529
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: YA1cSmgzhhBPTgO5McArbGDmcDky7/JLQGzfo7TbPZVxUsXWG2Lx4nRNhO5HtlsKbX6/tWrq/dw=
 < x-amz-request-id: 24C4A41FD826CB2D
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 25002-25529/541425806
 < Content-Type: image/tiff
 < Content-Length: 528
 < Server: AmazonS3
 < Duration: 0.041
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=26058-26063
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: iFl/5wXv6cJLHHl6Gxtz9ielR2ocIARHewK+uObzk7Y9Sc0oimRCpsy4gUTr2COdXNm9VlgXkmw=
 < x-amz-request-id: C3B06D419BA1ED76
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 26058-26063/541425806
 < Content-Type: image/tiff
 < Content-Length: 6
 < Server: AmazonS3
 < Duration: 0.043
DEBUG:aiocogeo.cog: Opened 1524x1285 overview
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=26238-26243
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: lMQ4XtXERvXrg/y4W4x511TmabkJlDsZqcTjB8j+AsaSVS0Yp+3xQ7d7QzWlUQHMEaXn5PfU7yQ=
 < x-amz-request-id: 28FD43C201EFB8F7
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 26238-26243/541425806
 < Content-Type: image/tiff
 < Content-Length: 6
 < Server: AmazonS3
 < Duration: 0.042
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=26388-26531
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: GvNDr2mb4krIgSac7weNXeUGP7U61kNw1Hbw4gRatAosYZuwqgssxOQRPKaG0m5iGubzNvftl10=
 < x-amz-request-id: 9DB1A848A4B4DB97
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 26388-26531/541425806
 < Content-Type: image/tiff
 < Content-Length: 144
 < Server: AmazonS3
 < Duration: 0.068
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=26244-26387
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: 0i+MOlBnco6XpODlZFA1gK3s5IdwLcCyMj5uISYwUvGEtRePS5y6zrhFQ3i/eYQmgy4GbnY0MQs=
 < x-amz-request-id: E90C709BF72BE0F9
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 26244-26387/541425806
 < Content-Type: image/tiff
 < Content-Length: 144
 < Server: AmazonS3
 < Duration: 0.041
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=26532-26537
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: wsVG1xc05idnG0xDDsoi0YyaTmrxS+utNVjMbL9k+X8nlyNinALVBB3qJfGeaFPxL+GfX7cFqIk=
 < x-amz-request-id: FA0E60D557F247B9
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 26532-26537/541425806
 < Content-Type: image/tiff
 < Content-Length: 6
 < Server: AmazonS3
 < Duration: 0.039
DEBUG:aiocogeo.cog: Opened 762x643 overview
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=26712-26717
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: dOMb5cQMKq7xm9iP05Z39g4vyscrelKRR6DfzzVmdLKt7PQQ309Cf//XVhq7oVzQhlsxkkJmehE=
 < x-amz-request-id: 012DFAC5C3FF1092
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 26712-26717/541425806
 < Content-Type: image/tiff
 < Content-Length: 6
 < Server: AmazonS3
 < Duration: 0.041
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=26754-26789
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: yTlRl5Zj6QLq1Q5Hsm4NkvoHuxvFzwCNI3kVUev6HqiccFT4FL48SDw/sY0ycHzolmoifmnn9ZU=
 < x-amz-request-id: 18D7BDE98B639198
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 26754-26789/541425806
 < Content-Type: image/tiff
 < Content-Length: 36
 < Server: AmazonS3
 < Duration: 0.04
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=26718-26753
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: X3Ffzdpw2J6YuLCOOQBv19y2xOK4SIWme8Bzgd5Zm/h2HBXeQasyb+CrjeCFqfo9/NCKpYTnvAg=
 < x-amz-request-id: 103E7221A6B84884
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 26718-26753/541425806
 < Content-Type: image/tiff
 < Content-Length: 36
 < Server: AmazonS3
 < Duration: 0.058
DEBUG:aiocogeo.filesystems:
 > GET /lzw_cog.tif HTTP/1.1
   Host: async-cog-reader-test-data.s3.amazonaws.com
   Range: bytes=26790-26795
DEBUG:aiocogeo.filesystems:
 < HTTP/1.1
 < x-amz-id-2: o86DtUheNNJPsUE84JAT8l9Y86da1vzy1xgh6vi545JTUqvzvHVDJivcpB/U0ycvLnKqk5uT6l4=
 < x-amz-request-id: C73B63361B972474
 < Date: Sun, 31 May 2020 20:37:36 GMT
 < Last-Modified: Wed, 08 Apr 2020 02:45:55 GMT
 < Etag: "811509701a23842f564f1549090704f3-32"
 < Accept-Ranges: bytes
 < Content-Range: bytes 26790-26795/541425806
 < Content-Type: image/tiff
 < Content-Length: 6
 < Server: AmazonS3
 < Duration: 0.039
DEBUG:aiocogeo.cog: Opened 381x322 overview

        FILE INFO: https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif

          PROFILE
            Width:            10280
            Height:           12190
            Bands:            3
            Dtype:            uint8
            Crs:              EPSG:26911
            Origin:           (367188.0, 3777102.0)
            Resolution:       (0.6, -0.6)
            BoundingBox:      (367188.0, 3769788.0, 373356.0, 3777102.0)
            Compression:      lzw
            Internal mask:    False
        
          IFD
                Id      Size           BlockSize     MinTileSize (KB)     MaxTileSize (KB)     MeanTileSize (KB)    
                0       10280x12190    512x512       56.144               926.81               802.006                       
                1       5140x6095      128x128       6.162                59.815               51.803                        
                2       2570x3048      128x128       4.143                59.686               52.215                        
                3       1285x1524      128x128       2.583                60.218               51.255                        
                4       643x762        128x128       1.84                 60.205               47.79                         
                5       322x381        128x128       29.517               59.102               48.474              
```