### PR TITLE
cache each range request

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/naip_i
 ### Configuration
 Configuration options are exposed through environment variables:
 - **INGESTED_BYTES_AT_OPEN** - defines the number of bytes in the first GET request at file opening (defaults to 16KB)
-- **ENABLE_BLOCK_CACHE** - determines if internal blocks are cached in memory (defaults to TRUE)
+- **ENABLE_CACHE** - determines if range requests are cached in memory (defaults to TRUE)
 - **HTTP_MERGE_CONSECUTIVE_RANGES** - determines if consecutive ranges are merged into a single request (defaults to FALSE)
 - **LOG_LEVEL** - determines the log level used by the package (defaults to ERROR)
 - **VERBOSE_LOGS** - enables verbose logging, designed for use when `LOG_LEVEL=DEBUG` (defaults to FALSE)

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin
 import uuid
 
-from aiocache import cached, Cache
 import affine
 import numpy as np
 
@@ -19,14 +18,6 @@ from .partial_reads import PartialReadInterface
 logger = logging.getLogger(__name__)
 logger.setLevel(config.LOG_LEVEL)
 
-def config_cache(fn: Callable) -> Callable:
-    """
-    Inject cache config params (https://aiocache.readthedocs.io/en/latest/decorators.html#aiocache.cached)
-    """
-    def wrap_function(*args, **kwargs):
-        kwargs['cache_read'] = kwargs['cache_write'] = config.ENABLE_BLOCK_CACHE
-        return fn(*args, **kwargs)
-    return wrap_function
 
 @dataclass
 class COGReader(PartialReadInterface):
@@ -158,11 +149,7 @@ class COGReader(PartialReadInterface):
             )
         return gt
 
-    @config_cache
-    @cached(
-        cache=Cache.MEMORY,
-        key_builder=lambda fn,*args,**kwargs: f"{args[0].filepath}-{args[1]}-{args[2]}-{args[3]}"
-    )
+
     async def get_tile(self, x: int, y: int, z: int) -> np.ndarray:
 
         """

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -17,7 +17,7 @@ INGESTED_BYTES_AT_OPEN: int = os.getenv("INGESTED_BYTES_AT_OPEN", 16384)
 
 # https://trac.osgeo.org/gdal/wiki/ConfigOptions#VSI_CACHE
 # Determines if in-memory block caching is enabled
-ENABLE_BLOCK_CACHE: bool = True if os.getenv(
+ENABLE_CACHE: bool = True if os.getenv(
     "ENABLE_BLOCK_CACHE", "TRUE"
 ).upper() == "TRUE" else False
 

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -18,7 +18,7 @@ INGESTED_BYTES_AT_OPEN: int = os.getenv("INGESTED_BYTES_AT_OPEN", 16384)
 # https://trac.osgeo.org/gdal/wiki/ConfigOptions#VSI_CACHE
 # Determines if in-memory block caching is enabled
 ENABLE_CACHE: bool = True if os.getenv(
-    "ENABLE_BLOCK_CACHE", "TRUE"
+    "ENABLE_CACHE", "TRUE"
 ).upper() == "TRUE" else False
 
 # https://trac.osgeo.org/gdal/wiki/ConfigOptions#GDAL_HTTP_MERGE_CONSECUTIVE_RANGES

--- a/aiocogeo/filesystems.py
+++ b/aiocogeo/filesystems.py
@@ -38,7 +38,7 @@ def config_cache(fn: Callable) -> Callable:
     Inject cache config params (https://aiocache.readthedocs.io/en/latest/decorators.html#aiocache.cached)
     """
     def wrap_function(*args, **kwargs):
-        kwargs['cache_read'] = kwargs['cache_write'] = config.ENABLE_BLOCK_CACHE
+        kwargs['cache_read'] = kwargs['cache_write'] = config.ENABLE_CACHE
         return fn(*args, **kwargs)
     return wrap_function
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ async def client_session():
 
 @pytest.fixture
 def create_cog_reader(client_session, monkeypatch):
-    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", False)
+    monkeypatch.setattr(config, "ENABLE_CACHE", False)
     def _create_reader(infile):
         return COGReader(filepath=infile)
 

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -285,7 +285,7 @@ async def test_cog_metadata_iter(infile, create_cog_reader):
 @pytest.mark.asyncio
 async def test_block_cache_enabled(create_cog_reader, monkeypatch):
     # Cache is disabled for tests
-    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", True)
+    monkeypatch.setattr(config, "ENABLE_CACHE", True)
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
     async with create_cog_reader(infile) as cog:
         await cog.get_tile(0,0,0)

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -289,10 +289,11 @@ async def test_block_cache_enabled(create_cog_reader, monkeypatch):
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
     async with create_cog_reader(infile) as cog:
         await cog.get_tile(0,0,0)
-        request_count = cog.requests['count']
 
+    async with create_cog_reader(infile) as cog:
         await cog.get_tile(0,0,0)
-        assert cog.requests['count'] == request_count
+        # Confirm all requests are cached
+        assert cog.requests['count'] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Caches each range request rather than each internal block.
    - This has the upside of caching the file header as well as each block.
    - The downside is the bytes themselves are cached instead of the decompressed array, so repeated calls to the same tile require decompressing multiple times.
- There is still work to be done to ensure we aren't caching the same byte multiple times in situations where a single byte is part of multiple ranges.
Ref #30 