### PR TITLE
track header size

### DIFF
--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -107,7 +107,8 @@ class COGReader(PartialReadInterface):
         return {
             'count': self._file_reader._total_requests,
             'byte_count': self._file_reader._total_bytes_requested,
-            'ranges': self._file_reader._requested_ranges
+            'ranges': self._file_reader._requested_ranges,
+            'header_size': self._file_reader._header_size
         }
 
     @property

--- a/aiocogeo/filesystems.py
+++ b/aiocogeo/filesystems.py
@@ -54,6 +54,7 @@ class Filesystem(abc.ABC):
         self._endian: str = "<"
         self._total_bytes_requested: int = 0
         self._total_requests: int = 0
+        self._header_size: int = config.INGESTED_BYTES_AT_OPEN
         self._requested_ranges = []
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/aiocogeo/scripts/cli.py
+++ b/aiocogeo/scripts/cli.py
@@ -114,6 +114,7 @@ async def info(
             {_make_bold("Compression:"):<{sep}} {cog.ifds[0].compression}
             {_make_bold("NoData:"):<{sep}} {profile['nodata']}
             {_make_bold("Internal mask:"):<{sep}} {cog.is_masked}
+            {_make_bold("Header size:"):<{sep}} {cog.requests['header_size']}
         """
         )
         typer.echo(


### PR DESCRIPTION
- Track header size.  The size of the header is number of bytes read at file opening (`INGESTED_BYTES_AT_OPEN` config) plus any additional bytes read during reading of the file header.  Additional bytes are read if the tag does not fit in the IFD (length > 4) and offset is greater than number of bytes read at file opening (https://github.com/geospatial-jeff/aiocogeo/blob/header-size/aiocogeo/tag.py#L79-L82).