### PR TITLE
add boundless reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Configuration options are exposed through environment variables:
 - **INGESTED_BYTES_AT_OPEN** - defines the number of bytes in the first GET request at file opening (defaults to 16KB)
 - **ENABLE_CACHE** - determines if range requests are cached in memory (defaults to TRUE)
 - **HTTP_MERGE_CONSECUTIVE_RANGES** - determines if consecutive ranges are merged into a single request (defaults to FALSE)
+- **BOUNDLESS_READ** - determines if internal tiles outside the bounds of the IFD are read (defaults to TRUE)
+- **BOUNDLESS_READ_FILL_VALUE** - determines the value used to fill boundless reads (defaults to 0)
 - **LOG_LEVEL** - determines the log level used by the package (defaults to ERROR)
 - **VERBOSE_LOGS** - enables verbose logging, designed for use when `LOG_LEVEL=DEBUG` (defaults to FALSE)
 

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -27,3 +27,15 @@ ENABLE_CACHE: bool = True if os.getenv(
 HTTP_MERGE_CONSECUTIVE_RANGES: bool = True if os.getenv(
     "HTTP_MERGE_CONSECUTIVE_RANGES", "FALSE"
 ).upper() == "TRUE" else False
+
+
+# Determines if internal tiles outside the bounds of the IFD are read. When set to ``TRUE`` (default), if a partial read
+# isn't fully covered by internal tiles, missing tiles will be created using the fill value defined by the
+# ``BOUNDLESS_READ_FILL_VALUE`` config option. When set to ``FALSE``, an exception will be raised instead
+BOUNDLESS_READ: bool = False if os.getenv(
+    "BOUNDLESS_READ", "TRUE"
+) == "FALSE" else True
+
+
+# Determines the fill value used for boundless reads
+BOUNDLESS_READ_FILL_VALUE: int = int(os.getenv("BOUNDLESS_READ_FILL_VALUE", "0"))

--- a/aiocogeo/ifd.py
+++ b/aiocogeo/ifd.py
@@ -127,8 +127,6 @@ class ImageIFD(OptionalTags, Compression, RequiredTags, IFD):
     async def _get_tile(self, x: int, y: int) -> np.ndarray:
         """Read the requested tile from the IFD"""
         idx = (y * self.tile_count[0]) + x
-        if idx > len(self.TileOffsets):
-            raise TileNotFoundError(f"Tile {x} {y} does not exist")
         offset = self.TileOffsets[idx]
         byte_count = self.TileByteCounts[idx] - 1
         img_bytes = await self._file_reader.range_request(offset, byte_count)
@@ -154,8 +152,6 @@ class MaskIFD(ImageIFD):
     async def _get_tile(self, x: int, y: int) -> np.ndarray:
         """Read the requested tile from the IFD"""
         idx = (y * self.tile_count[0]) + x
-        if idx > len(self.TileOffsets):
-            raise TileNotFoundError(f"Tile {x} {y} does not exist")
         offset = self.TileOffsets[idx]
         byte_count = self.TileByteCounts[idx] - 1
         img_bytes = await self._file_reader.range_request(offset, byte_count)

--- a/aiocogeo/partial_reads.py
+++ b/aiocogeo/partial_reads.py
@@ -83,6 +83,23 @@ class PartialReadBase(abc.ABC):
         """Determine if a mask needs to be added to the array"""
         return True if self.is_masked or (self.nodata is not None) else False
 
+    @staticmethod
+    def _intersect_bounds(
+        read_bounds: Tuple[float, float, float, float],
+        cog_bounds: Tuple[float, float, float, float]
+    ) -> bool:
+        """
+        Determine if a bounding box intersects another bounding box
+
+        https://github.com/cogeotiff/rio-tiler/blob/2.0a11/rio_tiler/utils.py#L254-L283
+        """
+        return (
+            (cog_bounds[0] < read_bounds[2])
+            and (cog_bounds[2] > read_bounds[0])
+            and (cog_bounds[3] > read_bounds[1])
+            and (cog_bounds[1] < read_bounds[3])
+        )
+
     def _get_overview_level(
         self, bounds: Tuple[float, float, float, float], width: int, height: int
     ) -> int:

--- a/aiocogeo/partial_reads.py
+++ b/aiocogeo/partial_reads.py
@@ -10,7 +10,7 @@ import affine
 import numpy as np
 from skimage.transform import resize
 
-from .filesystems import Filesystem
+from . import config
 from .ifd import ImageIFD, MaskIFD
 from .utils import run_in_background
 
@@ -81,7 +81,12 @@ class PartialReadBase(abc.ABC):
     @property
     def _add_mask(self) -> bool:
         """Determine if a mask needs to be added to the array"""
-        return True if self.is_masked or (self.nodata is not None) else False
+        if self.is_masked:
+            return True
+        if self.nodata is not None:
+            return True
+        return False
+
 
     @staticmethod
     def _intersect_bounds(

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -315,7 +315,7 @@ async def test_boundless_read_fill_value(create_cog_reader, monkeypatch):
         # Count number of pixels with a value of 1
         tile = await cog.read(bounds=bounds, shape=(256,256))
         counts = dict(zip(*np.unique(tile, return_counts=True)))
-        assert counts[1] == 5
+        assert counts[1] == 127
 
         # Set fill value of 1
         monkeypatch.setattr(config, "BOUNDLESS_READ_FILL_VALUE", 1)

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -323,7 +323,7 @@ async def test_boundless_read_fill_value(create_cog_reader, monkeypatch):
         # Count number of pixels with a value of 1
         tile = await cog.read(bounds=bounds, shape=(256,256))
         counts = dict(zip(*np.unique(tile, return_counts=True)))
-        assert counts[1] == 179629
+        assert counts[1] == 166142
 
 
 @pytest.mark.asyncio

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -1,4 +1,5 @@
 import math
+import random
 
 from morecantile.models import TileMatrixSet
 import mercantile
@@ -14,7 +15,7 @@ from shapely.geometry import Polygon
 from aiocogeo import config
 from aiocogeo.ifd import IFD
 from aiocogeo.tag import Tag
-from aiocogeo.errors import InvalidTiffError
+from aiocogeo.errors import InvalidTiffError, TileNotFoundError
 
 from .conftest import TEST_DATA
 
@@ -283,6 +284,65 @@ async def test_cog_read_merge_range_requests_with_internal_nodata_mask(create_co
     assert bytes_requested == merged_bytes_requested
     assert tile_data.all() == tile_data_merged.all()
     assert tile_data.shape == tile_data_merged.shape
+
+
+@pytest.mark.asyncio
+async def test_boundless_read(create_cog_reader, monkeypatch):
+    infile = "http://async-cog-reader-test-data.s3.amazonaws.com/webp_web_optimized_cog.tif"
+    tile = mercantile.Tile(x=701, y=1634, z=12)
+    bounds = mercantile.xy_bounds(tile)
+
+    # Confirm an exception is raised if boundless reads are disabled
+    monkeypatch.setattr(config, "BOUNDLESS_READ", False)
+
+    async with create_cog_reader(infile) as cog:
+        with pytest.raises(TileNotFoundError):
+            tile = await cog.read(bounds=bounds, shape=(256,256))
+
+    monkeypatch.setattr(config, "BOUNDLESS_READ", True)
+    async with create_cog_reader(infile) as cog:
+        await cog.read(bounds=bounds, shape=(256,256))
+
+
+@pytest.mark.asyncio
+async def test_boundless_read_fill_value(create_cog_reader, monkeypatch):
+    infile = "http://async-cog-reader-test-data.s3.amazonaws.com/webp_web_optimized_cog.tif"
+    tile = mercantile.Tile(x=701, y=1634, z=12)
+    bounds = mercantile.xy_bounds(tile)
+
+
+    async with create_cog_reader(infile) as cog:
+        # Count number of pixels with a value of 1
+        tile = await cog.read(bounds=bounds, shape=(256,256))
+        counts = dict(zip(*np.unique(tile, return_counts=True)))
+        assert counts[1] == 5
+
+        # Set fill value of 1
+        monkeypatch.setattr(config, "BOUNDLESS_READ_FILL_VALUE", 1)
+
+        # Count number of pixels with a value of 1
+        tile = await cog.read(bounds=bounds, shape=(256,256))
+        counts = dict(zip(*np.unique(tile, return_counts=True)))
+        assert counts[1] == 179629
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "infile", TEST_DATA
+)
+async def test_read_not_in_bounds(create_cog_reader, infile):
+    tile = mercantile.Tile(x=0,y=0,z=25)
+    bounds = mercantile.xy_bounds(tile)
+
+    async with create_cog_reader(infile) as cog:
+        if cog.epsg != 3857:
+            bounds = transform_bounds(
+                "EPSG:3857",
+                f"EPSG:{cog.epsg}",
+                *bounds
+            )
+        with pytest.raises(TileNotFoundError):
+            await cog.read(bounds=bounds, shape=(256,256))
 
 
 @pytest.mark.asyncio

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -330,6 +330,21 @@ async def test_boundless_read_fill_value(create_cog_reader, monkeypatch):
 @pytest.mark.parametrize(
     "infile", TEST_DATA
 )
+async def test_boundless_get_tile(create_cog_reader, infile, monkeypatch):
+    async with create_cog_reader(infile) as cog:
+        fill_value = random.randint(0, 100)
+        monkeypatch.setattr(config, "BOUNDLESS_READ_FILL_VALUE", fill_value)
+
+        # Test reading tiles outside of IFD when boundless reads is enabled
+        tile = await cog.get_tile(x=-1, y=-1, z=0)
+        counts = dict(zip(*np.unique(tile, return_counts=True)))
+        assert counts[fill_value] == tile.shape[0] * tile.shape[1] * tile.shape[2]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "infile", TEST_DATA
+)
 async def test_read_not_in_bounds(create_cog_reader, infile):
     tile = mercantile.Tile(x=0,y=0,z=25)
     bounds = mercantile.xy_bounds(tile)


### PR DESCRIPTION
- Adds `BOUNDLESS_READ` config option (defaults to `TRUE`) which determines whether internal tiles outside the bounds of the IFD are read.  When set to `TRUE`, if a partial read isn't fully covered by internal tiles, missing tiles will be created using the fill value defined by the ``BOUNDLESS_READ_FILL_VALUE`` config option.  When set to ``FALSE``, an exception will be raised when reading internal tiles.
- Adds `BOUNDLESS_READ_FILL_VALUE` config option (defaults to `0`).

This is primarily to support the dynamic tiling use case where web mercator tiles only partially cover the image.  When boundless reading is disabled, tiles which partially cover the image will not be read (as this will raise an exception).  At lower zooms where tiles are larger this may cause many tiles to not render:

![image](https://user-images.githubusercontent.com/40916268/84581243-d485c600-ada4-11ea-8e38-66bf0f397d3d.png)


When boundless reads are enabled, these tiles will be read and filled with the fill value (in this case 0):

![image](https://user-images.githubusercontent.com/40916268/84581256-fa12cf80-ada4-11ea-9292-30e4396a41d4.png)


Because boundless reads requires reading tiles which are not a part of the IFD, it can lead to non-intuitive behavior for `get_tile`, such as reading tiles with negative x/y indices:

```python
from aiocogeo import COGReader

async with COGReader(infile) as cog:
    tile = await cog.get_tile(x=-1, y=-1, z=0)
    # zero-filled array
    print(tile)
```


Closes #26 