### PR TITLE
use pil resize

### DIFF
--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 import uuid
 
 import affine
+from PIL import Image
 import numpy as np
 
 from . import config
@@ -203,7 +204,12 @@ class COGReader(PartialReadInterface):
             return np.ma.masked_where(tile[0] == ifd.nodata, tile[0])
         return tile[0]
 
-    async def read(self, bounds: Tuple[float, float, float, float], shape: Tuple[int, int]) -> Union[np.ndarray, np.ma.masked_array]:
+    async def read(
+        self,
+        bounds: Tuple[float, float, float, float],
+        shape: Tuple[int, int],
+        resample_method: int = Image.NEAREST,
+    ) -> Union[np.ndarray, np.ma.masked_array]:
         """
         Perform a partial read.  All pixels within the specified bounding box are read from the image and the array is
         resampled to match the desired shape.
@@ -234,7 +240,8 @@ class COGReader(PartialReadInterface):
             self._postprocess,
             arr=img_arr,
             img_tiles=img_tiles,
-            out_shape=shape
+            out_shape=shape,
+            resample_method=resample_method
         )
 
         return postprocessed

--- a/aiocogeo/partial_reads.py
+++ b/aiocogeo/partial_reads.py
@@ -2,17 +2,16 @@
 import asyncio
 import abc
 from dataclasses import dataclass
-from functools import partial
 import math
 from typing import List, Optional, Tuple, Union
 
 import affine
 import numpy as np
-from skimage.transform import resize
+from PIL import Image
 
-from . import config
 from .ifd import ImageIFD, MaskIFD
 from .utils import run_in_background
+
 
 NpArrayType = Union[np.ndarray, np.ma.masked_array]
 
@@ -271,20 +270,13 @@ class PartialReadBase(abc.ABC):
         self, clipped: NpArrayType, img_tiles: TileMetadata, out_shape: Tuple[int, int]
     ) -> NpArrayType:
         """Resample a numpy array to the desired shape"""
-        resized = resize(
-            clipped,
-            output_shape=(img_tiles.bands, out_shape[0], out_shape[1]),
-            preserve_range=True,
-            anti_aliasing=True,
-        ).astype(img_tiles.dtype)
+        img = Image.fromarray(np.rollaxis(clipped, 0, 3))
+        resized = img.resize((out_shape[0], out_shape[1]), resample=Image.BILINEAR)
+        resized = np.rollaxis(np.array(resized), 2, 0)
         if self._add_mask:
-            resized_mask = resize(
-                clipped.mask,
-                output_shape=(img_tiles.bands, out_shape[0], out_shape[1]),
-                preserve_range=True,
-                anti_aliasing=False,
-                order=0,
-            )
+            mask = Image.fromarray(clipped.mask[0,...])
+            resized_mask = np.array(mask.resize((out_shape[0], out_shape[1]), resample=Image.NEAREST))
+            resized_mask = np.stack((resized_mask for _ in range(img_tiles.bands)))
             resized = np.ma.masked_array(resized, resized_mask)
         return resized
 

--- a/aiocogeo/partial_reads.py
+++ b/aiocogeo/partial_reads.py
@@ -72,7 +72,7 @@ class PartialReadBase(abc.ABC):
 
     @abc.abstractmethod
     async def read(
-        self, bounds: Tuple[float, float, float, float], shape: Tuple[int, int]
+        self, bounds: Tuple[float, float, float, float], shape: Tuple[int, int], resample_method: int
     ) -> Union[np.ndarray, np.ma.masked_array]:
         """Do a partial read"""
         ...
@@ -267,7 +267,7 @@ class PartialReadBase(abc.ABC):
         ]
 
     def _resample(
-        self, clipped: NpArrayType, img_tiles: TileMetadata, out_shape: Tuple[int, int]
+        self, clipped: NpArrayType, img_tiles: TileMetadata, out_shape: Tuple[int, int], resample_method: int
     ) -> NpArrayType:
         """Resample a numpy array to the desired shape"""
         img = Image.fromarray(np.rollaxis(clipped, 0, 3))
@@ -275,17 +275,17 @@ class PartialReadBase(abc.ABC):
         resized = np.rollaxis(np.array(resized), 2, 0)
         if self._add_mask:
             mask = Image.fromarray(clipped.mask[0,...])
-            resized_mask = np.array(mask.resize((out_shape[0], out_shape[1]), resample=Image.NEAREST))
+            resized_mask = np.array(mask.resize((out_shape[0], out_shape[1]), resample=resample_method))
             resized_mask = np.stack((resized_mask for _ in range(img_tiles.bands)))
             resized = np.ma.masked_array(resized, resized_mask)
         return resized
 
     def _postprocess(
-        self, arr: NpArrayType, img_tiles: TileMetadata, out_shape: Tuple[int, int]
+        self, arr: NpArrayType, img_tiles: TileMetadata, out_shape: Tuple[int, int], resample_method: int
     ) -> NpArrayType:
         """Wrapper around ``_clip_array`` and ``_resample`` to postprocess the partial read"""
         return self._resample(
-            self._clip_array(arr, img_tiles), img_tiles=img_tiles, out_shape=out_shape
+            self._clip_array(arr, img_tiles), img_tiles=img_tiles, out_shape=out_shape, resample_method=resample_method
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         "aiocache",
         "affine",
         "imagecodecs",
-        "scikit-image",
         "typer",
     ],
     test_suite="tests",

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "affine",
         "imagecodecs",
         "typer",
+        "Pillow"
     ],
     test_suite="tests",
     setup_requires=[

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -315,7 +315,7 @@ async def test_boundless_read_fill_value(create_cog_reader, monkeypatch):
         # Count number of pixels with a value of 1
         tile = await cog.read(bounds=bounds, shape=(256,256))
         counts = dict(zip(*np.unique(tile, return_counts=True)))
-        assert counts[1] == 127
+        assert counts[1] == 418
 
         # Set fill value of 1
         monkeypatch.setattr(config, "BOUNDLESS_READ_FILL_VALUE", 1)
@@ -323,7 +323,7 @@ async def test_boundless_read_fill_value(create_cog_reader, monkeypatch):
         # Count number of pixels with a value of 1
         tile = await cog.read(bounds=bounds, shape=(256,256))
         counts = dict(zip(*np.unique(tile, return_counts=True)))
-        assert counts[1] == 166142
+        assert counts[1] == 167645
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Uses PIL resize instead of skimage resize to lower memory footprint.
- Expose resampling method to caller

```python
from PIL import Image

async with COGReader("http://async-cog-reader-test-data.s3.amazonaws.com/webp_web_optimized_cog.tif") as cog:
    tile = await cog.read(..., resample_method=Image.CUBIC)
```

Closes #56 