### PR TITLE
reuse aiohttp session

### DIFF
--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -1,7 +1,7 @@
 import asyncio
 from dataclasses import dataclass, field
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin
 import uuid
 
@@ -30,10 +30,11 @@ class COGReader(PartialReadInterface):
     _version: Optional[int] = 42
     _big_tiff: Optional[bool] = False
 
+    kwargs: Optional[Dict] = field(default_factory=dict)
 
     async def __aenter__(self):
         """Open the image and read the header"""
-        async with Filesystem.create_from_filepath(self.filepath) as file_reader:
+        async with Filesystem.create_from_filepath(self.filepath, **self.kwargs) as file_reader:
             self._file_reader = file_reader
             if (await file_reader.read(2)) == b"MM":
                 file_reader._endian = ">"

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     tests_require=[
         "mercantile",
         "morecantile",
-        "pytest",
+        "pytest<5.4",
         "pytest-asyncio<0.11.0",
         "pytest-cov",
         "rasterio",

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -1,6 +1,7 @@
 import math
 import random
 
+import aiohttp
 from morecantile.models import TileMatrixSet
 import mercantile
 import numpy as np
@@ -12,7 +13,7 @@ from rio_tiler.io import cogeo
 from rio_tiler import utils as rio_tiler_utils
 from shapely.geometry import Polygon
 
-from aiocogeo import config
+from aiocogeo import config, COGReader
 from aiocogeo.ifd import IFD
 from aiocogeo.tag import Tag
 from aiocogeo.errors import InvalidTiffError, TileNotFoundError
@@ -450,3 +451,13 @@ async def test_file_not_found(create_cog_reader, infile):
     with pytest.raises(FileNotFoundError):
         async with create_cog_reader(infile) as cog:
             ...
+
+
+@pytest.mark.asyncio
+async def test_inject_session():
+    async with aiohttp.ClientSession() as session:
+        async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif", kwargs={"session": session}):
+            pass
+        # Confirm session is still open
+        assert not session.closed
+        assert session._trace_configs


### PR DESCRIPTION
Add `kwargs` to filesystem, allowing reusing an aiohttp session across multiple instances of `COGReader`.