### PR TITLE
correnctly handle resampling method

### DIFF
--- a/aiocogeo/partial_reads.py
+++ b/aiocogeo/partial_reads.py
@@ -274,12 +274,12 @@ class PartialReadBase(abc.ABC):
         if clipped.shape[0] == 1:
             _clipped = np.squeeze(_clipped, axis=2)
         img = Image.fromarray(_clipped)
-        resized = np.array(img.resize((out_shape[0], out_shape[1]), resample=Image.BILINEAR)).astype(img_tiles.dtype)
+        resized = np.array(img.resize((out_shape[0], out_shape[1]), resample=resample_method)).astype(img_tiles.dtype)
         if clipped.shape[0] != 1:
             resized = np.rollaxis(resized, 2, 0)
         if self._add_mask:
             mask = Image.fromarray(clipped.mask[0,...])
-            resized_mask = np.array(mask.resize((out_shape[0], out_shape[1]), resample=resample_method))
+            resized_mask = np.array(mask.resize((out_shape[0], out_shape[1]), resample=Image.BILINEAR))
             resized_mask = np.stack((resized_mask for _ in range(img_tiles.bands)))
             resized = np.ma.masked_array(resized, resized_mask)
         return resized

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -330,7 +330,7 @@ async def test_boundless_read_fill_value(create_cog_reader, monkeypatch):
         # Count number of pixels with a value of 1
         tile = await cog.read(bounds=bounds, shape=(256,256))
         counts = dict(zip(*np.unique(tile, return_counts=True)))
-        assert counts[1] == 418
+        assert counts[1] == 351
 
         # Set fill value of 1
         monkeypatch.setattr(config, "BOUNDLESS_READ_FILL_VALUE", 1)
@@ -338,7 +338,7 @@ async def test_boundless_read_fill_value(create_cog_reader, monkeypatch):
         # Count number of pixels with a value of 1
         tile = await cog.read(bounds=bounds, shape=(256,256))
         counts = dict(zip(*np.unique(tile, return_counts=True)))
-        assert counts[1] == 167645
+        assert counts[1] == 167583
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Resampling method defined by the user is applied to the image.
- Mask resampling set to bilinear, experimentally it seems to perform the best on binary masks.

Thanks @vincentsarago
