### PR TITLE
stac reader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       # https://nose.readthedocs.io
       - run:
           name: run tests
-          command: python setup.py pytest
+          command: pip install -U setuptools && python setup.py pytest
 
       - codecov/upload:
           file: "coverage.xml"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       # https://nose.readthedocs.io
       - run:
           name: run tests
-          command: pip install -U setuptools && python setup.py pytest
+          command: pip install -e .[dev] && pytest -v
 
       - codecov/upload:
           file: "coverage.xml"

--- a/aiocogeo/__init__.py
+++ b/aiocogeo/__init__.py
@@ -1,1 +1,2 @@
-from .cog import COGReader
+from .cog import COGReader, CompositeReader
+from .stac import STACReader

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -330,6 +330,6 @@ class COGReader(PartialReadInterface):
 class CompositeReader:
     readers: List[COGReader]
 
-    async def apply(self, func: Callable):
+    async def apply(self, func: Callable) -> List[Any]:
         futs = [func(reader) for reader in self.readers]
         return await asyncio.gather(*futs)

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -357,7 +357,7 @@ class COGReader(ReaderMixin, PartialReadInterface):
         return tms
 
 
-FilterType = Callable[[Any], Any]
+FilterType = Callable[[COGReader], Any]
 MapType = Callable[[COGReader], Any]
 ReduceType = Callable[[List[Union[np.ndarray, np.ma.masked_array]]], Any]
 

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -360,14 +360,13 @@ class COGReader(ReaderMixin, PartialReadInterface):
 
 @dataclass
 class CompositeReader(ReaderMixin):
-    readers: List[COGReader]
+    readers: Optional[List[COGReader]] = field(default_factory=list)
     aliases: Optional[List[str]] = None
 
     def __post_init__(self):
         if self.aliases:
             for idx, alias in enumerate(self.aliases):
                 setattr(self, alias, self.readers[idx])
-
 
     async def apply(self, func: Callable) -> List[Any]:
         futs = [func(reader) for reader in self.readers]

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -333,3 +333,35 @@ class CompositeReader:
     async def apply(self, func: Callable) -> List[Any]:
         futs = [func(reader) for reader in self.readers]
         return await asyncio.gather(*futs)
+
+    async def get_tile(self, x: int, y: int, z: int) -> List[np.ndarray]:
+        """Fetch a tile from all readers"""
+        return await self.apply(
+            func=lambda r: r.get_tile(x, y, z),
+        )
+
+    async def read(
+        self,
+        bounds: Tuple[float, float, float, float],
+        shape: Tuple[int, int],
+        resample_method: int = Image.NEAREST,
+    ):
+        return await self.apply(
+            func=lambda r: r.read(bounds, shape, resample_method)
+        )
+
+    async def point(self, x: Union[float, int], y: Union[float, int]) -> List[Union[np.ndarray, np.ma.masked_array]]:
+        return await self.apply(
+            func=lambda r: r.point(x, y)
+        )
+
+    async def preview(
+        self,
+        max_size: int = 1024,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        resample_method: int = Image.NEAREST
+    ) -> List[Union[np.ndarray, np.ma.masked_array]]:
+        return await self.apply(
+            func=lambda r: r.preview(max_size, height, width, resample_method)
+        )

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -361,6 +361,13 @@ class COGReader(ReaderMixin, PartialReadInterface):
 @dataclass
 class CompositeReader(ReaderMixin):
     readers: List[COGReader]
+    aliases: Optional[List[str]] = None
+
+    def __post_init__(self):
+        if self.aliases:
+            for idx, alias in enumerate(self.aliases):
+                setattr(self, alias, self.readers[idx])
+
 
     async def apply(self, func: Callable) -> List[Any]:
         futs = [func(reader) for reader in self.readers]

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -2,7 +2,7 @@ import asyncio
 from dataclasses import dataclass, field
 import logging
 import math
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin
 import uuid
 
@@ -323,3 +323,13 @@ class COGReader(PartialReadInterface):
             "tileMatrix": list(reversed(matrices))
         }
         return tms
+
+
+
+@dataclass
+class CompositeReader:
+    readers: List[COGReader]
+
+    async def apply(self, func: Callable):
+        futs = [func(reader) for reader in self.readers]
+        return await asyncio.gather(*futs)

--- a/aiocogeo/errors.py
+++ b/aiocogeo/errors.py
@@ -14,3 +14,8 @@ class InvalidTiffError(CogReadError):
 @dataclass
 class TileNotFoundError(CogReadError):
     ...
+
+
+@dataclass
+class MissingAssets(CogReadError):
+    ...

--- a/aiocogeo/filesystems.py
+++ b/aiocogeo/filesystems.py
@@ -189,10 +189,11 @@ class HttpFilesystem(Filesystem):
     async def _on_request_end(self, session, trace_config_ctx, params):
         if params.response.status < 400:
             elapsed = round(asyncio.get_event_loop().time() - trace_config_ctx.start, 3)
-            content_range = params.response.headers['Content-Range']
+            content_range = params.response.headers.get('Content-Range')
             self._total_bytes_requested += int(params.response.headers["Content-Length"])
             self._total_requests += 1
-            self._requested_ranges.append(tuple([int(v) for v in content_range.split(' ')[-1].split('/')[0].split('-')]))
+            if content_range:
+                self._requested_ranges.append(tuple([int(v) for v in content_range.split(' ')[-1].split('/')[0].split('-')]))
             if config.VERBOSE_LOGS:
                 debug_statement = [f"\n < HTTP/{session.version.major}.{session.version.minor}"]
                 debug_statement += [f"\n < {k}: {v}" for (k, v) in params.response.headers.items()]

--- a/aiocogeo/stac.py
+++ b/aiocogeo/stac.py
@@ -16,6 +16,11 @@ except ModuleNotFoundError:
 
 
 @dataclass
+class AssetReader(COGReader):
+    asset: Asset = Asset
+
+
+@dataclass
 class STACReader(CompositeReader):
     filepath: Optional[str] = None
     include_types: Set[MimeTypes] = field(default_factory=lambda: {MimeTypes.cog})
@@ -33,8 +38,10 @@ class STACReader(CompositeReader):
         aliases = []
         for asset in item["assets"]:
             if item["assets"][asset]["type"] in self.include_types:
-                reader = COGReader(item["assets"][asset]["href"])
-                reader.asset = Asset(name=asset, **item["assets"][asset])
+                reader = AssetReader(
+                    filepath=item["assets"][asset]["href"],
+                    asset=Asset(name=asset, **item['assets'][asset])
+                )
                 reader = reader.__aenter__()
                 reader_futs.append(reader)
                 aliases.append(asset)

--- a/aiocogeo/stac.py
+++ b/aiocogeo/stac.py
@@ -38,19 +38,3 @@ class STACReader:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         for reader in self.reader.readers:
             await reader._file_reader._close()
-
-    async def get_tile(self, x: int, y: int, z: int) -> List[np.ndarray]:
-        """Fetch a tile from all readers"""
-        return await self.reader.apply(
-            func=lambda r: r.get_tile(x, y, z),
-        )
-
-    async def read(
-        self,
-        bounds: Tuple[float, float, float, float],
-        shape: Tuple[int, int],
-        resample_method: int = Image.NEAREST,
-    ):
-        return await self.reader.apply(
-            func=lambda r: r.read(bounds, shape, resample_method)
-        )

--- a/aiocogeo/stac.py
+++ b/aiocogeo/stac.py
@@ -6,6 +6,7 @@ from stac_pydantic.shared import Asset, MimeTypes
 
 from .cog import COGReader, CompositeReader
 from .filesystems import Filesystem
+from .errors import MissingAssets
 
 
 @dataclass
@@ -35,6 +36,9 @@ class STACReader(CompositeReader):
                     asset=Asset(name=asset, **item['assets'][asset])
                 )
                 reader_futs.append(reader)
+
+        if not reader_futs:
+            raise MissingAssets(f"No assets found of type {self.include_types}")
 
         reader_futs = map(lambda r: r.__aenter__(), filter(self.filter, reader_futs))
         self.readers = await asyncio.gather(*reader_futs)

--- a/aiocogeo/stac.py
+++ b/aiocogeo/stac.py
@@ -38,7 +38,6 @@ class STACReader(CompositeReader):
 
         reader_futs = map(lambda r: r.__aenter__(), filter(self.filter, reader_futs))
         self.readers = await asyncio.gather(*reader_futs)
-        self.__post_init__()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/aiocogeo/stac.py
+++ b/aiocogeo/stac.py
@@ -1,6 +1,6 @@
 import asyncio
 from dataclasses import dataclass, field
-from typing import List, Set, Tuple
+from typing import List, Optional, Set, Tuple, Union
 from urllib.parse import urlsplit
 
 import aiohttp
@@ -8,14 +8,14 @@ import numpy as np
 from PIL import Image
 from stac_pydantic.shared import MimeTypes
 
-from .cog import COGReader, CompositeReader
+from .cog import COGReader, CompositeReader, ReaderMixin
 
 
 @dataclass
-class STACReader:
+class STACReader(ReaderMixin):
     filepath: str
     reader: CompositeReader = None
-    include_types: Set[MimeTypes] = field(default_factory={MimeTypes.cog})
+    include_types: Set[MimeTypes] = field(default_factory=lambda: {MimeTypes.cog})
 
     async def __aenter__(self):
         splits = urlsplit(self.filepath)
@@ -30,13 +30,39 @@ class STACReader:
 
         # Create a reader for each asset with a COG mime type
         reader_futs = []
+        aliases = []
         for asset in item["assets"]:
             if item["assets"][asset]["type"] in self.include_types:
                 reader = COGReader(item["assets"][asset]["href"]).__aenter__()
                 reader_futs.append(reader)
-        self.reader = CompositeReader(await asyncio.gather(*reader_futs))
+                aliases.append(asset)
+        self.reader = CompositeReader(await asyncio.gather(*reader_futs), aliases=aliases)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         for reader in self.reader.readers:
             await reader._file_reader._close()
+
+
+    async def get_tile(self, x: int, y: int, z: int) -> Union[np.ndarray, List[np.ndarray]]:
+        return await self.reader.get_tile(x, y, z)
+
+    async def read(
+        self,
+        bounds: Tuple[float, float, float, float],
+        shape: Tuple[int, int],
+        resample_method: int = Image.NEAREST,
+    ) -> Union[Union[np.ndarray, np.ma.masked_array], List[Union[np.ndarray, np.ma.masked_array]]]:
+        return await self.reader.read(bounds, shape, resample_method)
+
+    async def point(self, x: Union[float, int], y: Union[float, int]) -> Union[Union[np.ndarray, np.ma.masked_array], List[Union[np.ndarray, np.ma.masked_array]]]:
+        return await self.reader.point(x, y)
+
+    async def preview(
+        self,
+        max_size: int = 1024,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        resample_method: int = Image.NEAREST
+    ) -> Union[Union[np.ndarray, np.ma.masked_array], List[Union[np.ndarray, np.ma.masked_array]]]:
+        return await self.reader.preview(max_size, height, width, resample_method)

--- a/aiocogeo/stac.py
+++ b/aiocogeo/stac.py
@@ -1,12 +1,10 @@
 import asyncio
 from dataclasses import dataclass, field
-from typing import List, Optional, Set, Tuple, Union
+from typing import Optional, Set
 from urllib.parse import urlsplit
 
 import aiohttp
-import numpy as np
-from PIL import Image
-from stac_pydantic.shared import MimeTypes
+from stac_pydantic.shared import Asset, MimeTypes
 
 from .cog import COGReader, CompositeReader
 
@@ -34,7 +32,7 @@ class STACReader(CompositeReader):
         for asset in item["assets"]:
             if item["assets"][asset]["type"] in self.include_types:
                 reader = COGReader(item["assets"][asset]["href"])
-                reader.alias = asset
+                reader.asset = Asset(name=asset, **item["assets"][asset])
                 reader = reader.__aenter__()
                 reader_futs.append(reader)
                 aliases.append(asset)

--- a/aiocogeo/stac.py
+++ b/aiocogeo/stac.py
@@ -8,13 +8,6 @@ from .cog import COGReader, CompositeReader
 from .filesystems import Filesystem
 
 
-try:
-    import aioboto3
-    has_s3 = True
-except ModuleNotFoundError:
-    has_s3 = False
-
-
 @dataclass
 class AssetReader(COGReader):
     asset: Asset = Asset

--- a/aiocogeo/stac.py
+++ b/aiocogeo/stac.py
@@ -33,9 +33,14 @@ class STACReader(CompositeReader):
         aliases = []
         for asset in item["assets"]:
             if item["assets"][asset]["type"] in self.include_types:
-                reader = COGReader(item["assets"][asset]["href"]).__aenter__()
+                reader = COGReader(item["assets"][asset]["href"])
+                reader.alias = asset
+                reader = reader.__aenter__()
                 reader_futs.append(reader)
                 aliases.append(asset)
+        self.readers = await asyncio.gather(*reader_futs)
+        self.aliases = aliases
+        self.__post_init__()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/aiocogeo/stac.py
+++ b/aiocogeo/stac.py
@@ -1,10 +1,11 @@
 import asyncio
 from dataclasses import dataclass
-from typing import List
+from typing import List, Tuple
 from urllib.parse import urlsplit
 
 import aiohttp
 import numpy as np
+from PIL import Image
 
 from .cog import COGReader, CompositeReader
 
@@ -38,8 +39,18 @@ class STACReader:
         for reader in self.reader.readers:
             await reader._file_reader._close()
 
-    async def get_tile(self, x: int, y: int, z: int) -> np.ndarray:
+    async def get_tile(self, x: int, y: int, z: int) -> List[np.ndarray]:
         """Fetch a tile from all readers"""
         return await self.reader.apply(
             func=lambda r: r.get_tile(x, y, z),
+        )
+
+    async def read(
+        self,
+        bounds: Tuple[float, float, float, float],
+        shape: Tuple[int, int],
+        resample_method: int = Image.NEAREST,
+    ):
+        return await self.reader.apply(
+            func=lambda r: r.read(bounds, shape, resample_method)
         )

--- a/aiocogeo/stac.py
+++ b/aiocogeo/stac.py
@@ -1,0 +1,41 @@
+import asyncio
+from dataclasses import dataclass
+from typing import List
+from urllib.parse import urlsplit
+
+import aiohttp
+
+from .cog import COGReader
+
+
+@dataclass
+class STACReader:
+    filepath: str
+    readers: List[COGReader] = None
+
+    async def __aenter__(self):
+        splits = urlsplit(self.filepath)
+        if splits.scheme in {"http", "https"}:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(self.filepath) as resp:
+                    resp.raise_for_status()
+                    item = await resp.json()
+        else:
+            # TODO: support s3
+            pass
+
+        reader_futs = []
+        for asset in item["assets"]:
+            if item["assets"][asset]["type"] == "image/x.geotiff":
+                reader = COGReader(item["assets"][asset]["href"]).__aenter__()
+                reader_futs.append(reader)
+        self.readers = await asyncio.gather(*reader_futs)
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        for reader in self.readers:
+            await reader._file_reader._close()
+
+    async def get_tile(self, x: int, y: int, z: int):
+        futs = [reader.get_tile(x, y, z) for reader in self.readers]
+        return await asyncio.gather(*futs)

--- a/aiocogeo/stac.py
+++ b/aiocogeo/stac.py
@@ -28,18 +28,16 @@ class STACReader(CompositeReader):
 
         # Create a reader for each asset with a COG mime type
         reader_futs = []
-        aliases = []
         for asset in item["assets"]:
             if item["assets"][asset]["type"] in self.include_types:
                 reader = AssetReader(
                     filepath=item["assets"][asset]["href"],
                     asset=Asset(name=asset, **item['assets'][asset])
                 )
-                reader = reader.__aenter__()
                 reader_futs.append(reader)
-                aliases.append(asset)
+
+        reader_futs = map(lambda r: r.__aenter__(), filter(self.filter, reader_futs))
         self.readers = await asyncio.gather(*reader_futs)
-        self.aliases = aliases
         self.__post_init__()
         return self
 

--- a/aiocogeo/tiler.py
+++ b/aiocogeo/tiler.py
@@ -1,6 +1,8 @@
+import abc
+import asyncio
 from dataclasses import dataclass
 import math
-from typing import List, Tuple, Type
+from typing import Any, Callable, List, Tuple, Type
 
 import numpy as np
 from PIL import Image
@@ -36,7 +38,55 @@ class COGInfo:
 
 
 @dataclass
-class COGTiler:
+class TilerMixin(abc.ABC):
+
+    @abc.abstractmethod
+    async def tile(
+        self,
+        x: int,
+        y: int,
+        z: int,
+        tile_size: int = 256,
+        tms: TileMatrixSet = DEFAULT_TMS,
+        resample_method: int = Image.NEAREST,
+    ) -> np.ndarray:
+        ...
+
+    @abc.abstractmethod
+    async def point(
+        self,
+        coords: Tuple[float, float],
+        coords_crs: CRS = WGS84,
+    ) -> np.ndarray:
+        ...
+
+    @abc.abstractmethod
+    async def part(
+        self,
+        bounds: Tuple[float, float, float, float],
+        bounds_crs: CRS = WGS84,
+        width: int = None,
+        height: int = None
+    ) -> np.ndarray:
+        ...
+
+    @abc.abstractmethod
+    async def preview(
+        self,
+        width: int = None,
+        height: int = None,
+        max_size: int = 1024,
+        resample_method: int = Image.NEAREST,
+    ):
+        ...
+
+    @abc.abstractmethod
+    async def info(self) -> COGInfo:
+        ...
+
+
+@dataclass
+class COGTiler(TilerMixin):
     cog: Type[ReaderMixin]
 
     def __post_init__(self):
@@ -168,4 +218,53 @@ class COGTiler:
             bounds=list(wgs84_bounds),
             dtype=self.profile["dtype"],
             color_interp=self.profile["photometric"],
+        )
+
+
+@dataclass
+class CompositeTiler(TilerMixin):
+    readers: List[COGTiler]
+
+    async def apply(self, func: Callable) -> List[Any]:
+        futs = [func(reader) for reader in self.readers]
+        return await asyncio.gather(*futs)
+
+    async def tile(
+        self,
+        x: int,
+        y: int,
+        z: int,
+        tile_size: int = 256,
+        tms: TileMatrixSet = DEFAULT_TMS,
+        resample_method: int = Image.NEAREST,
+    ) -> np.ndarray:
+        return await self.apply(
+            func=lambda r: r.tile(x, y, z, tile_size, tms, resample_method)
+        )
+
+    async def part(
+        self,
+        bounds: Tuple[float, float, float, float],
+        bounds_crs: CRS = WGS84,
+        width: int = None,
+        height: int = None
+    ) -> np.ndarray:
+        return await self.apply(
+            func=lambda r: r.part(bounds, bounds_crs, width, height)
+        )
+
+    async def preview(
+        self,
+        width: int = None,
+        height: int = None,
+        max_size: int = 1024,
+        resample_method: int = Image.NEAREST,
+    ):
+        return await self.apply(
+            func=lambda r: r.preview(width, height, max_size, resample_method)
+        )
+
+    async def info(self) -> COGInfo:
+        return await self.apply(
+            func=lambda f: r.info()
         )

--- a/aiocogeo/tiler.py
+++ b/aiocogeo/tiler.py
@@ -223,6 +223,7 @@ class COGTiler(TilerMixin):
 
 @dataclass
 class CompositeTiler(TilerMixin):
+    # TODO: Add reducers
     readers: List[COGTiler]
 
     async def apply(self, func: Callable) -> List[Any]:

--- a/aiocogeo/tiler.py
+++ b/aiocogeo/tiler.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 import math
-from typing import List, Tuple
+from typing import List, Tuple, Type
 
 import numpy as np
 from PIL import Image
 
-from .cog import COGReader
+from .cog import COGReader, ReaderMixin
 
 try:
     import morecantile
@@ -37,7 +37,7 @@ class COGInfo:
 
 @dataclass
 class COGTiler:
-    cog: COGReader
+    cog: Type[ReaderMixin]
 
     def __post_init__(self):
         self.profile = self.cog.profile

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,20 @@ with open("README.md") as f:
 
 extras = {
     "s3": ["aioboto3"],
-    "tiler": ["morecantile", "rasterio", "rio-tiler==2.0b9"]
+    "tiler": ["morecantile", "rasterio", "rio-tiler==2.0b9"],
+    "dev": [
+        "mercantile",
+        "morecantile",
+        "rasterio",
+        "rio-tiler==2.0b9",
+        "pytest<5.4",
+        "pytest-asyncio<0.11.0",
+        "pytest-cov",
+        "shapely",
+        "botocore==1.15.32",
+        "boto3==1.12.32",
+        "aioboto3",
+    ]
 }
 
 setup(
@@ -48,17 +61,5 @@ setup(
     ],
     entry_points={"console_scripts": ["aiocogeo=aiocogeo.scripts.cli:app"]},
     extras_require=extras,
-    tests_require=[
-        "mercantile",
-        "morecantile",
-        "rasterio",
-        "rio-tiler==2.0b9",
-        "pytest<5.4",
-        "pytest-asyncio<0.11.0",
-        "pytest-cov",
-        "shapely",
-        "botocore==1.15.32",
-        "boto3==1.12.32",
-        "aioboto3",
-    ]
+    tests_require=extras['dev']
 )

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
         "imagecodecs",
         "typer",
         "Pillow",
-        "stac-pydantic>=1.3.*"
+        "stac-pydantic>=1.3.*",
+        "geojson-pydantic==0.1.0"
     ],
     test_suite="tests",
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
         "affine",
         "imagecodecs",
         "typer",
-        "Pillow"
+        "Pillow",
+        "stac-pydantic>=1.3.*"
     ],
     test_suite="tests",
     setup_requires=[

--- a/tests/test_composite_reader.py
+++ b/tests/test_composite_reader.py
@@ -1,0 +1,65 @@
+import asyncio
+
+import pytest
+from aiocogeo import CompositeReader, COGReader
+
+
+@pytest.fixture
+async def readers():
+    readers = await asyncio.gather(
+        *[COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif").__aenter__() for _ in range(2)]
+    )
+    yield readers
+    for reader in readers:
+        await reader._file_reader._close()
+
+
+@pytest.mark.asyncio
+async def test_composite_reader(readers):
+    composite_reader = CompositeReader(
+        readers=readers
+    )
+    for reader in composite_reader:
+        assert isinstance(reader, COGReader)
+
+
+@pytest.mark.asyncio
+async def test_composite_reader_get_tile(readers):
+    composite_reader = CompositeReader(
+        readers=readers
+    )
+    tiles = await composite_reader.get_tile(x=0, y=0, z=0)
+    assert (tiles[0] == tiles[1]).all()
+
+
+@pytest.mark.asyncio
+async def test_composite_reader_read(readers):
+    composite_reader = CompositeReader(
+        readers=readers
+    )
+    bounds = readers[0].bounds
+    tiles = await composite_reader.read(bounds=bounds, shape=(256, 256))
+    assert (tiles[0] == tiles[1]).all()
+
+
+@pytest.mark.asyncio
+async def test_composite_reader_point(readers):
+    composite_reader = CompositeReader(
+        readers=readers
+    )
+    bounds = readers[0].bounds
+    center = (
+        (bounds[0] + bounds[2]) / 2,
+        (bounds[1] + bounds[3]) / 2
+    )
+    tiles = await composite_reader.point(*center)
+    assert (tiles[0] == tiles[1]).all()
+
+
+@pytest.mark.asyncio
+async def test_composite_reader_preview(readers):
+    composite_reader = CompositeReader(
+        readers=readers
+    )
+    previews = await composite_reader.preview()
+    assert (previews[0] == previews[1]).all()

--- a/tests/test_stac_reader.py
+++ b/tests/test_stac_reader.py
@@ -1,0 +1,57 @@
+import pytest
+
+import aiohttp
+from aiocogeo.errors import MissingAssets
+from aiocogeo.stac import STACReader
+from stac_pydantic.shared import MimeTypes
+
+STAC_ITEM = "https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/S5_11055_6057_20070622.json"
+
+@pytest.mark.asyncio
+async def test_stac_reader():
+    async with STACReader(
+        filepath=STAC_ITEM,
+    ) as reader:
+        assert len(reader.readers) == 5
+
+
+@pytest.mark.asyncio
+async def test_stac_reader_include_types():
+    async with STACReader(
+        filepath=STAC_ITEM, include_types={MimeTypes.cog}
+    ) as reader:
+        assert len(reader.readers) == 5
+
+
+    with pytest.raises(MissingAssets):
+        async with STACReader(
+            filepath=STAC_ITEM, include_types={MimeTypes.geopackage}
+        ):
+            ...
+
+
+@pytest.mark.asyncio
+async def test_stac_reader_reuse_session():
+    async with aiohttp.ClientSession() as session:
+        async with STACReader(
+            filepath=STAC_ITEM,
+            kwargs={"session": session}
+        ) as reader:
+            pass
+        assert not session.closed
+
+
+"""
+async def main():
+    async with STACReader(
+        filepath="http://stac.arturo.ai/collections/naip/items/m_3311717_nw_11_060_20180723",
+        include_types={MimeTypes.cog}, # Only try to read COG types
+        filter=lambda a: a.asset.name == "analytic_cog" # Filter for the asset with NIR band
+    ) as reader:
+        val = await reader.point(
+            x=412382.1,
+            y=3731494.7,
+            reducer=ndvi
+        )
+        print(val)
+"""

--- a/tests/test_stac_reader.py
+++ b/tests/test_stac_reader.py
@@ -39,19 +39,3 @@ async def test_stac_reader_reuse_session():
         ) as reader:
             pass
         assert not session.closed
-
-
-"""
-async def main():
-    async with STACReader(
-        filepath="http://stac.arturo.ai/collections/naip/items/m_3311717_nw_11_060_20180723",
-        include_types={MimeTypes.cog}, # Only try to read COG types
-        filter=lambda a: a.asset.name == "analytic_cog" # Filter for the asset with NIR band
-    ) as reader:
-        val = await reader.point(
-            x=412382.1,
-            y=3731494.7,
-            reducer=ndvi
-        )
-        print(val)
-"""


### PR DESCRIPTION
Closes #69 

This PR adds a `CompositeReader` which allows performing the same operation over multiple `COGReader` instances via MapReduce.  Composite readers  implement the same interface as a normal reader (enforced through the `ReaderMixin` class).  Also add the `STACReader` which extends `CompositeReader`.

The caller can easily implement their own filter/map/reduce functions, for example calculating ndvi from an naip stac item:

```python
import asyncio
import os

os.environ['AWS_REQUEST_PAYER'] = "requester"

from aiocogeo.stac import STACReader
from stac_pydantic.shared import MimeTypes

def ndvi(arr):
    arr = arr[0]
    return (arr[3] - arr[1]) / (arr[3] + arr[1])

async def main():
    async with STACReader(
        filepath="http://stac.arturo.ai/collections/naip/items/m_3311717_nw_11_060_20180723",
        include_types={MimeTypes.cog}, # Only try to read COG types
        filter=lambda a: a.asset.name == "analytic_cog" # Filter for the asset with NIR band
    ) as reader:
        val = await reader.point(
            x=412382.1,
            y=3731494.7,
            reducer=ndvi
        )
        print(val)


asyncio.run(main())

>>> 0.35686275
```