### PR TITLE
support GDAL_METADATA private tag

### DIFF
--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -120,12 +120,7 @@ class COGReader(ReaderMixin, PartialReadInterface):
     @property
     def epsg(self) -> int:
         """Return the EPSG code representing the crs of the image"""
-        ifd = self.ifds[0]
-        for idx in range(0, len(ifd.GeoKeyDirectoryTag), 4):
-            # 2048 is geographic crs
-            # 3072 is projected crs
-            if ifd.GeoKeyDirectoryTag[idx] in (2048, 3072):
-                return ifd.GeoKeyDirectoryTag[idx + 3]
+        return self.ifds[0].geo_keys.epsg
 
     @property
     def bounds(self) -> Tuple[float, float, float, float]:

--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -233,8 +233,6 @@ class COGReader(ReaderMixin, PartialReadInterface):
             interp = [ColorInterp.undefined for _ in range(self.profile['count'])]
         return interp
 
-
-
     @property
     def has_alpha(self) -> bool:
         """Check if the image has an alpha band"""
@@ -247,6 +245,10 @@ class COGReader(ReaderMixin, PartialReadInterface):
     @property
     def nodata(self) -> Optional[int]:
         return self.ifds[0].nodata
+
+    @property
+    def gdal_metadata(self) -> Dict:
+        return self.ifds[0].gdal_metadata
 
     async def _read_header(self) -> None:
         """Internal method to read image header and parse into IFDs and Tags"""

--- a/aiocogeo/constants.py
+++ b/aiocogeo/constants.py
@@ -200,6 +200,13 @@ GDAL_METADATA_TAGS = [
 ]
 
 
+RASTER_TYPE = {
+    0: "Unknown",
+    1: "Area",
+    2: "Point",
+}
+
+
 class MaskFlags(enum.IntEnum):
     """https://github.com/mapbox/rasterio/blob/master/rasterio/enums.py#L80-L84"""
     all_valid = 1

--- a/aiocogeo/constants.py
+++ b/aiocogeo/constants.py
@@ -159,6 +159,7 @@ TIFF_TAGS = {
     33550: "ModelPixelScaleTag",
     33922: "ModelTiepointTag",
     34735: "GeoKeyDirectoryTag",
+    42112: "GdalMetadata",
     42113: "NoData"
 }
 

--- a/aiocogeo/constants.py
+++ b/aiocogeo/constants.py
@@ -176,6 +176,13 @@ TIFF_TAGS = {
 }
 
 
+GEO_KEYS = {
+    1025: "RasterType",
+    2048: "GeographicType",
+    3072: "ProjectedType",
+}
+
+
 # https://gdal.org/drivers/raster/gtiff.html#metadata
 GDAL_METADATA_TAGS = [
     "DocumentName",

--- a/aiocogeo/constants.py
+++ b/aiocogeo/constants.py
@@ -145,8 +145,19 @@ TIFF_TAGS = {
     258: "BitsPerSample",
     259: "Compression",
     262: "PhotometricInterpretation",
+    269: "DocumentName",
+    270: "ImageDescription",
     277: "SamplesPerPixel",
+    280: "MinSampleValue",
+    281: "MaxSampleValue",
+    282: "XResolution",
+    283: "YResolution",
     284: "PlanarConfiguration",
+    296: "ResolutionUnit",
+    305: "Software",
+    306: "DateTime",
+    315: "Artist",
+    316: "HostComputer",
     317: "Predictor",
     320: "ColorMap",
     322: "TileWidth",
@@ -156,12 +167,31 @@ TIFF_TAGS = {
     338: "ExtraSamples",
     339: "SampleFormat",
     347: "JPEGTables",
+    33432: "Copyright",
     33550: "ModelPixelScaleTag",
     33922: "ModelTiepointTag",
     34735: "GeoKeyDirectoryTag",
     42112: "GdalMetadata",
     42113: "NoData"
 }
+
+
+# https://gdal.org/drivers/raster/gtiff.html#metadata
+GDAL_METADATA_TAGS = [
+    "DocumentName",
+    "ImageDescription",
+    "Software",
+    "DateTime",
+    "Artist",
+    "HostComputer",
+    "Copyright",
+    "XResolution",
+    "YResolution",
+    "ResolutionUnit",
+    "MinSampleValue",
+    "MaxSampleValue"
+]
+
 
 class MaskFlags(enum.IntEnum):
     """https://github.com/mapbox/rasterio/blob/master/rasterio/enums.py#L80-L84"""

--- a/aiocogeo/ifd.py
+++ b/aiocogeo/ifd.py
@@ -6,7 +6,7 @@ import numpy as np
 import xmltodict
 
 from .compression import Compression
-from .constants import COMPRESSIONS, GDAL_METADATA_TAGS, INTERLEAVE, SAMPLE_DTYPES
+from .constants import COMPRESSIONS, GDAL_METADATA_TAGS, INTERLEAVE, RASTER_TYPE, SAMPLE_DTYPES
 from .filesystems import Filesystem
 from .tag import GeoKeyDirectory, Tag
 from .utils import run_in_background
@@ -198,6 +198,9 @@ class ImageIFD(OptionalTags, Compression, RequiredTags, IFD):
                 meta.update({tag['@name']:tag['#text'] for tag in tags})
             else:
                 meta.update({tags['@name']:tags['#text']})
+
+        if self.geo_keys:
+            meta['AREA_OR_POINT'] = RASTER_TYPE[self.geo_keys.RasterType.value]
 
         return meta
 

--- a/aiocogeo/ifd.py
+++ b/aiocogeo/ifd.py
@@ -8,7 +8,7 @@ import xmltodict
 from .compression import Compression
 from .constants import COMPRESSIONS, GDAL_METADATA_TAGS, INTERLEAVE, SAMPLE_DTYPES
 from .filesystems import Filesystem
-from .tag import Tag
+from .tag import GeoKeyDirectory, Tag
 from .utils import run_in_background
 
 @dataclass
@@ -16,6 +16,7 @@ class IFD:
     next_ifd_offset: int
     tag_count: int
     _file_reader: Filesystem
+
 
     @staticmethod
     def _is_masked(tiff_tags: Dict[str, Tag]) -> bool:
@@ -44,6 +45,9 @@ class IFD:
                 tiff_tags[tag.name] = tag
         file_reader.seek(ifd_start + (12 * tag_count) + 2)
         next_ifd_offset = await file_reader.read(4, cast_to_int=True)
+
+        if 'GeoKeyDirectoryTag' in tiff_tags:
+            tiff_tags['geo_keys'] = GeoKeyDirectory.read(tiff_tags['GeoKeyDirectoryTag'])
 
         # Check if mask
         if cls._is_masked(tiff_tags):
@@ -86,7 +90,6 @@ class OptionalTags:
     MinSampleValue: Tag = None
     MaxSampleValue: Tag = None
 
-
     # GeoTiff
     GeoKeyDirectoryTag: Tag = None
     ModelPixelScaleTag: Tag = None
@@ -100,6 +103,7 @@ class OptionalTags:
 @dataclass
 class ImageIFD(OptionalTags, Compression, RequiredTags, IFD):
     _is_alpha: bool = False
+    geo_keys: Optional[GeoKeyDirectory] = None
 
     @property
     def is_alpha(self) -> bool:
@@ -200,7 +204,7 @@ class ImageIFD(OptionalTags, Compression, RequiredTags, IFD):
     def __iter__(self):
         """Iterate through TIFF Tags"""
         for (k, v) in self.__dict__.items():
-            if k not in ("next_ifd_offset", "tag_count", "_file_reader") and v:
+            if k not in ("next_ifd_offset", "tag_count", "_file_reader", "geo_keys") and v:
                 yield v
 
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "Pillow",
         "stac-pydantic>=1.3.*",
         "geojson-pydantic==0.1.0",
-        "xmljson"
+        "xmltodict"
     ],
     test_suite="tests",
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
         "typer",
         "Pillow",
         "stac-pydantic>=1.3.*",
-        "geojson-pydantic==0.1.0"
+        "geojson-pydantic==0.1.0",
+        "xmljson"
     ],
     test_suite="tests",
     setup_requires=[

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -18,7 +18,7 @@ from shapely.geometry import Polygon
 
 from aiocogeo import config, COGReader
 from aiocogeo.ifd import IFD
-from aiocogeo.tag import Tag
+from aiocogeo.tag import Tag, BaseTag
 from aiocogeo.tiler import COGTiler
 from aiocogeo.errors import InvalidTiffError, TileNotFoundError
 from aiocogeo.constants import MaskFlags
@@ -530,7 +530,7 @@ async def test_cog_metadata_iter(infile, create_cog_reader):
         for ifd in cog:
             assert isinstance(ifd, IFD)
             for tag in ifd:
-                assert isinstance(tag, Tag)
+                assert isinstance(tag, BaseTag)
 
 
 @pytest.mark.asyncio

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -46,7 +46,7 @@ async def test_cog_metadata(infile, create_cog_reader):
             gdal_metadata = cog.gdal_metadata
 
             for (k,v) in rio_tags.items():
-                if k in ("TIFFTAG_XRESOLUTION", "TIFFTAG_YRESOLUTION", "TIFFTAG_RESOLUTIONUNIT", "AREA_OR_POINT"):
+                if k in ("TIFFTAG_XRESOLUTION", "TIFFTAG_YRESOLUTION", "TIFFTAG_RESOLUTIONUNIT"):
                     continue
                 assert str(gdal_metadata[k]) == v
 

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -42,6 +42,14 @@ async def test_cog_metadata(infile, create_cog_reader):
             assert rio_profile == cog_profile
             assert ds.overviews(1) == cog.overviews
 
+            rio_tags = ds.tags()
+            gdal_metadata = cog.gdal_metadata
+
+            for (k,v) in rio_tags.items():
+                if k in ("TIFFTAG_XRESOLUTION", "TIFFTAG_YRESOLUTION", "TIFFTAG_RESOLUTIONUNIT", "AREA_OR_POINT"):
+                    continue
+                assert str(gdal_metadata[k]) == v
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("infile", TEST_DATA)


### PR DESCRIPTION
support `GDAL_METADATA` private tag (same as rasterio dataset tags), parse XML into dict.


```python
from aiocogeo import COGReader

async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/cog_alpha_band.tif") as cog:
    print(cog.gdal_metadata)

>>> {'OVR_RESAMPLING_ALG': 'NEAREST'}
```