### PR TITLE
[WIP] add header cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/naip_i
 ### Configuration
 Configuration options are exposed through environment variables:
 - **INGESTED_BYTES_AT_OPEN** - defines the number of bytes in the first GET request at file opening (defaults to 16KB)
-- **ENABLE_CACHE** - determines if range requests are cached in memory (defaults to TRUE)
+- **ENABLE_BLOCK_CACHE** - determines if image blocks are cached in memory (defaults to TRUE)
+- **ENABLE_HEADER_CACHE** - determines if COG headers are cached in memory (defaults to TRUE)
 - **HTTP_MERGE_CONSECUTIVE_RANGES** - determines if consecutive ranges are merged into a single request (defaults to FALSE)
 - **BOUNDLESS_READ** - determines if internal tiles outside the bounds of the IFD are read (defaults to TRUE)
 - **BOUNDLESS_READ_FILL_VALUE** - determines the value used to fill boundless reads (defaults to 0)

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -17,9 +17,17 @@ INGESTED_BYTES_AT_OPEN: int = os.getenv("INGESTED_BYTES_AT_OPEN", 16384)
 
 # https://trac.osgeo.org/gdal/wiki/ConfigOptions#VSI_CACHE
 # Determines if in-memory block caching is enabled
-ENABLE_CACHE: bool = True if os.getenv(
-    "ENABLE_CACHE", "TRUE"
+ENABLE_BLOCK_CACHE: bool = True if os.getenv(
+    "ENABLE_BLOCK_CACHE", "TRUE"
 ).upper() == "TRUE" else False
+
+
+# enable caching of header requests, similar to GDAL's VSI CACHE
+# https://trac.osgeo.org/gdal/wiki/ConfigOptions#VSI_CACHE
+ENABLE_HEADER_CACHE: bool = True if os.getenv(
+    "ENABLE_HEADER_CACHE", "TRUE"
+).upper() == "TRUE" else False
+
 
 # https://trac.osgeo.org/gdal/wiki/ConfigOptions#GDAL_HTTP_MERGE_CONSECUTIVE_RANGES
 # Determines if consecutive range requests are merged into a single request, reducing the number of HTTP GET range

--- a/aiocogeo/filesystems.py
+++ b/aiocogeo/filesystems.py
@@ -40,9 +40,10 @@ def config_cache(fn: Callable) -> Callable:
     Inject cache config params (https://aiocache.readthedocs.io/en/latest/decorators.html#aiocache.cached)
     """
     def wrap_function(*args, **kwargs):
-        if kwargs['is_header'] and config.ENABLE_HEADER_CACHE:
+        is_header = kwargs.get('is_header', None)
+        if is_header and config.ENABLE_HEADER_CACHE:
             should_cache = True
-        elif config.ENABLE_BLOCK_CACHE:
+        elif config.ENABLE_BLOCK_CACHE and not is_header:
             should_cache = True
         else:
             should_cache = False
@@ -87,7 +88,7 @@ class Filesystem(abc.ABC):
         cache=Cache.MEMORY,
         key_builder=lambda fn,*args,**kwargs: f"{args[0].filepath}-{args[1]}-{args[2]}"
     )
-    async def range_request(self, start: int, offset: int, is_header: bool = True) -> bytes:
+    async def range_request(self, start: int, offset: int, **kwargs) -> bytes:
         """
         Perform and cache a range request.
         """
@@ -110,7 +111,7 @@ class Filesystem(abc.ABC):
         ...
 
 
-    async def read(self, offset: int, cast_to_int: bool = False, is_header: bool = True):
+    async def read(self, offset: int, cast_to_int: bool = False, is_header: bool = False):
         """
         Read from the current offset (self._offset) to the specified offset and optionall cast the result to int
         """

--- a/aiocogeo/filesystems.py
+++ b/aiocogeo/filesystems.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 import json
 import logging
 import time
-from typing import Any, Callable, Dict, Union
+from typing import Callable, Dict
 from urllib.parse import urlsplit
 
 from aiocache import cached, Cache
@@ -40,7 +40,13 @@ def config_cache(fn: Callable) -> Callable:
     Inject cache config params (https://aiocache.readthedocs.io/en/latest/decorators.html#aiocache.cached)
     """
     def wrap_function(*args, **kwargs):
-        kwargs['cache_read'] = kwargs['cache_write'] = config.ENABLE_CACHE
+        if kwargs['is_header'] and config.ENABLE_HEADER_CACHE:
+            should_cache = True
+        elif config.ENABLE_BLOCK_CACHE:
+            should_cache = True
+        else:
+            should_cache = False
+        kwargs['cache_read'] = kwargs['cache_write'] = should_cache
         return fn(*args, **kwargs)
     return wrap_function
 
@@ -81,7 +87,7 @@ class Filesystem(abc.ABC):
         cache=Cache.MEMORY,
         key_builder=lambda fn,*args,**kwargs: f"{args[0].filepath}-{args[1]}-{args[2]}"
     )
-    async def range_request(self, start: int, offset: int) -> bytes:
+    async def range_request(self, start: int, offset: int, is_header: bool = True) -> bytes:
         """
         Perform and cache a range request.
         """
@@ -104,12 +110,12 @@ class Filesystem(abc.ABC):
         ...
 
 
-    async def read(self, offset: int, cast_to_int: bool = False):
+    async def read(self, offset: int, cast_to_int: bool = False, is_header: bool = True):
         """
         Read from the current offset (self._offset) to the specified offset and optionall cast the result to int
         """
         if self._offset + offset > len(self.data):
-            self.data += await self.range_request(len(self.data), config.INGESTED_BYTES_AT_OPEN)
+            self.data += await self.range_request(len(self.data), config.INGESTED_BYTES_AT_OPEN, is_header=is_header)
         data = self.data[self._offset : self._offset + offset]
         self.incr(offset)
         order = "little" if self._endian == "<" else "big"

--- a/aiocogeo/tag.py
+++ b/aiocogeo/tag.py
@@ -83,7 +83,7 @@ class Tag(BaseTag):
             end_of_tag = reader.tell()
             if value_offset + length > INGESTED_BYTES_AT_OPEN:
                 # Increment header size if more data is read
-                data = await reader.range_request(value_offset, length - 1)
+                data = await reader.range_request(value_offset, length - 1, is_header=True)
                 reader._header_size += length
             else:
                 reader.seek(value_offset)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,8 +42,8 @@ def create_cog_reader(client_session, monkeypatch):
     monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", False)
     monkeypatch.setattr(config, "ENABLE_HEADER_CACHE", False)
 
-    def _create_reader(infile):
-        return COGReader(filepath=infile)
+    def _create_reader(infile, **kwargs):
+        return COGReader(filepath=infile, **kwargs)
 
     return _create_reader
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,8 @@ async def client_session():
 
 @pytest.fixture
 def create_cog_reader(client_session, monkeypatch):
-    monkeypatch.setattr(config, "ENABLE_CACHE", False)
+    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", False)
+    monkeypatch.setattr(config, "ENABLE_HEADER_CACHE", False)
 
     def _create_reader(infile):
         return COGReader(filepath=infile)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,16 +6,21 @@ import pytest
 from .conftest import TEST_DATA
 
 from aiocogeo.scripts.cli import app
+from aiocogeo import config
 
 
 @pytest.mark.parametrize("infile", TEST_DATA[:-1])
-def test_info(cli_runner, infile):
+def test_info(cli_runner, infile, monkeypatch):
+    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", False)
+    monkeypatch.setattr(config, "ENABLE_HEADER_CACHE", False)
     result = cli_runner.invoke(app, ["info", infile])
     assert result.exit_code == 0
 
 
 @pytest.mark.parametrize("infile", TEST_DATA[:-1])
-def test_info_json_formatted(cli_runner, infile):
+def test_info_json_formatted(cli_runner, infile, monkeypatch):
+    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", False)
+    monkeypatch.setattr(config, "ENABLE_HEADER_CACHE", False)
     json_result = cli_runner.invoke(app, ["info", infile, "--json"])
     assert json_result.exit_code == 0
 
@@ -23,7 +28,9 @@ def test_info_json_formatted(cli_runner, infile):
 
 
 @pytest.mark.parametrize("infile", TEST_DATA)
-def test_create_tms(cli_runner, infile):
+def test_create_tms(cli_runner, infile, monkeypatch):
+    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", False)
+    monkeypatch.setattr(config, "ENABLE_HEADER_CACHE", False)
     result = cli_runner.invoke(app, ["create-tms", infile])
     assert result.exit_code == 0
 

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -522,6 +522,33 @@ async def test_block_cache_disabled(create_cog_reader):
 
 
 @pytest.mark.asyncio
+async def test_header_cache_enabled(create_cog_reader, monkeypatch):
+    # Cache is disabled for tests
+    monkeypatch.setattr(config, "ENABLE_HEADER_CACHE", True)
+    infile = "https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif"
+    async with COGReader(infile) as cog:
+        assert cog.requests["count"] == 20
+
+    async with COGReader(infile) as cog:
+        assert cog.requests["count"] == 2
+
+    async with COGReader(infile) as cog:
+        await cog.get_tile(0, 0, 0)
+        assert cog.requests["count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_header_cache_disabled(create_cog_reader):
+    infile = "https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif"
+    async with create_cog_reader(infile) as cog:
+        assert cog.requests["count"] == 20
+
+    async with create_cog_reader(infile) as cog:
+        assert cog.requests["count"] == 20
+
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("infile", TEST_DATA)
 async def test_cog_request_metadata(create_cog_reader, infile):
     async with create_cog_reader(infile) as cog:

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -499,7 +499,7 @@ async def test_cog_metadata_iter(infile, create_cog_reader):
 @pytest.mark.asyncio
 async def test_block_cache_enabled(create_cog_reader, monkeypatch):
     # Cache is disabled for tests
-    monkeypatch.setattr(config, "ENABLE_CACHE", True)
+    monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", True)
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
     async with create_cog_reader(infile) as cog:
         await cog.get_tile(0, 0, 0)
@@ -507,7 +507,7 @@ async def test_block_cache_enabled(create_cog_reader, monkeypatch):
     async with create_cog_reader(infile) as cog:
         await cog.get_tile(0, 0, 0)
         # Confirm all requests are cached
-        assert cog.requests["count"] == 0
+        assert cog.requests["count"] == 18
 
 
 @pytest.mark.asyncio

--- a/tests/test_cog_reader.py
+++ b/tests/test_cog_reader.py
@@ -495,7 +495,7 @@ async def test_cog_metadata_iter(infile, create_cog_reader):
             for tag in ifd:
                 assert isinstance(tag, BaseTag)
 
-
+#
 @pytest.mark.asyncio
 async def test_block_cache_enabled(create_cog_reader, monkeypatch):
     # Cache is disabled for tests
@@ -526,13 +526,13 @@ async def test_header_cache_enabled(create_cog_reader, monkeypatch):
     # Cache is disabled for tests
     monkeypatch.setattr(config, "ENABLE_HEADER_CACHE", True)
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif"
-    async with COGReader(infile) as cog:
+    async with create_cog_reader(infile) as cog:
         assert cog.requests["count"] == 20
 
-    async with COGReader(infile) as cog:
+    async with create_cog_reader(infile) as cog:
         assert cog.requests["count"] == 2
 
-    async with COGReader(infile) as cog:
+    async with create_cog_reader(infile) as cog:
         await cog.get_tile(0, 0, 0)
         assert cog.requests["count"] == 3
 
@@ -586,9 +586,9 @@ async def test_file_not_found(create_cog_reader, infile):
 
 
 @pytest.mark.asyncio
-async def test_inject_session():
+async def test_inject_session(create_cog_reader):
     async with aiohttp.ClientSession() as session:
-        async with COGReader(
+        async with create_cog_reader(
             "https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif",
             kwargs={"session": session},
         ):


### PR DESCRIPTION
Differentiate between header ad block cache by injecting the `is_header` kwarg into the memoizer.  Ref #82 



```python
import os

os.environ['ENABLE_HEADER_CACHE'] = 'TRUE'
os.environ['ENABLE_BLOCK_CACHE'] = 'FALSE'

from aiocogeo import COGReader
import asyncio

async def main():
    async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif") as cog:
        await cog.get_tile(0,0,0)
        assert cog.requests['count'] == 21

    async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif") as cog:
        await cog.get_tile(0,0,0)
        assert cog.requests['count'] == 3


asyncio.run(main())
```