### PR TITLE
chunk transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ async with COGReader("https://async-cog-reader-test-data.s3.amazonaws.com/naip_i
 ### Configuration
 Configuration options are exposed through environment variables:
 - **INGESTED_BYTES_AT_OPEN** - defines the number of bytes in the first GET request at file opening (defaults to 16KB)
+- **HEADER_CHUNK_SIZE** - chunk size used to read header (defaults to 16KB)
 - **ENABLE_BLOCK_CACHE** - determines if image blocks are cached in memory (defaults to TRUE)
 - **ENABLE_HEADER_CACHE** - determines if COG headers are cached in memory (defaults to TRUE)
 - **HTTP_MERGE_CONSECUTIVE_RANGES** - determines if consecutive ranges are merged into a single request (defaults to FALSE)

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -15,6 +15,9 @@ VERBOSE_LOGS: bool = False if os.getenv("VERBOSE_LOGS", "FALSE") == "FALSE" else
 # Can help performance when reading images with a large header
 INGESTED_BYTES_AT_OPEN: int = os.getenv("INGESTED_BYTES_AT_OPEN", 16384)
 
+# Defines the chunk size used for additional GET requests required to read the header
+HEADER_CHUNK_SIZE: int = os.getenv("HEADER_CHUNK_SIZE", 16384)
+
 # https://trac.osgeo.org/gdal/wiki/ConfigOptions#VSI_CACHE
 # Determines if in-memory block caching is enabled
 ENABLE_BLOCK_CACHE: bool = True if os.getenv(

--- a/aiocogeo/ifd.py
+++ b/aiocogeo/ifd.py
@@ -38,14 +38,8 @@ class IFD:
         ifd_start = file_reader.tell()
         tag_count = await file_reader.read(2, cast_to_int=True, is_header=True)
         tiff_tags = {}
-
-        tags = await asyncio.gather(
-            *[
-                Tag.read(file_reader, offset=ifd_start + (12 * idx) + 2)
-                for idx in range(tag_count)
-            ]
-        )
-        for tag in tags:
+        for idx in range(tag_count):
+            tag = await Tag.read(file_reader)
             if tag:
                 tiff_tags[tag.name] = tag
         file_reader.seek(ifd_start + (12 * tag_count) + 2)

--- a/aiocogeo/ifd.py
+++ b/aiocogeo/ifd.py
@@ -36,14 +36,14 @@ class IFD:
     async def read(cls, file_reader: Filesystem) -> Union["ImageIFD", "MaskIFD"]:
         """Read the IFD"""
         ifd_start = file_reader.tell()
-        tag_count = await file_reader.read(2, cast_to_int=True, is_header=True)
+        tag_count = await file_reader.read(2, cast_to_int=True)
         tiff_tags = {}
         for idx in range(tag_count):
             tag = await Tag.read(file_reader)
             if tag:
                 tiff_tags[tag.name] = tag
         file_reader.seek(ifd_start + (12 * tag_count) + 2)
-        next_ifd_offset = await file_reader.read(4, cast_to_int=True, is_header=True)
+        next_ifd_offset = await file_reader.read(4, cast_to_int=True)
 
         if 'GeoKeyDirectoryTag' in tiff_tags:
             tiff_tags['geo_keys'] = GeoKeyDirectory.read(tiff_tags['GeoKeyDirectoryTag'])

--- a/aiocogeo/tag.py
+++ b/aiocogeo/tag.py
@@ -85,9 +85,12 @@ class Tag(BaseTag):
             end_of_tag = reader.tell()
 
             # read more data if we need to
-            # TODO: this will fail if chunks size is smaller than the tag value
-            if value_offset + length > len(reader.data):
-                reader.data += await reader.range_request(len(reader.data), HEADER_CHUNK_SIZE, is_header=True)
+            current_size = len(reader.data)
+            if value_offset + length > current_size:
+
+                # we coerce the chunk size to be at least the size of the tag
+                chunk_size = max(value_offset + length - current_size, HEADER_CHUNK_SIZE)
+                reader.data += await reader.range_request(len(reader.data), chunk_size, is_header=True)
 
             # read the tag value
             reader.seek(value_offset)

--- a/aiocogeo/tag.py
+++ b/aiocogeo/tag.py
@@ -4,13 +4,13 @@ import struct
 
 from typing import Any, Optional, Tuple, Union
 
-from .config import HEADER_CHUNK_SIZE, LOG_LEVEL
+from . import config
 from .constants import GEO_KEYS, TIFF_TAGS
 from .filesystems import Filesystem
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(LOG_LEVEL)
+logger.setLevel(config.LOG_LEVEL)
 
 
 @dataclass
@@ -89,7 +89,7 @@ class Tag(BaseTag):
             if value_offset + length > current_size:
 
                 # we coerce the chunk size to be at least the size of the tag
-                chunk_size = max(value_offset + length - current_size, HEADER_CHUNK_SIZE)
+                chunk_size = max(value_offset + length - current_size, config.HEADER_CHUNK_SIZE)
                 reader.data += await reader.range_request(len(reader.data), chunk_size, is_header=True)
 
             # read the tag value

--- a/aiocogeo/tag.py
+++ b/aiocogeo/tag.py
@@ -84,31 +84,16 @@ class Tag(BaseTag):
             value_offset = await reader.read(4, cast_to_int=True)
             end_of_tag = reader.tell()
 
+            # read more data if we need to
+            # TODO: dedup with `Filesystem.read`
             if value_offset + length > len(reader.data):
                 reader.data += await reader.range_request(len(reader.data), INGESTED_BYTES_AT_OPEN, is_header=True)
 
+            # read the tag value
             reader.seek(value_offset)
             data = await reader.read(length)
-
-
-
-
-            # await reader.read(value_offset + length - reader.tell())
-            # reader.seek(value_offset)
-            # data = await reader.read(length)
-
-
-
-            # value_offset = await reader.read(4, cast_to_int=True)
-            # end_of_tag = reader.tell()
-            # if value_offset + length > INGESTED_BYTES_AT_OPEN:
-            #     # Increment header size if more data is read
-            #     data = await reader.range_request(value_offset, length - 1, is_header=True)
-            #     reader._header_size += length
-            # else:
-            #     reader.seek(value_offset)
-            #     data = await reader.read(length)
             value = struct.unpack(f"{reader._endian}{count}{field_type.format}", data)
+
             reader.seek(end_of_tag)
         value = value[0] if count == 1 else value
 

--- a/aiocogeo/tag.py
+++ b/aiocogeo/tag.py
@@ -55,7 +55,6 @@ class Tag(BaseTag):
     @classmethod
     async def read(cls, reader: Filesystem) -> Optional["Tag"]:
         """Read a TIFF Tag"""
-        # reader.seek(offset)
         # 0-2 bytes of tag are tag name
         code = await reader.read(2, cast_to_int=True)
         if code not in TIFF_TAGS:
@@ -88,7 +87,7 @@ class Tag(BaseTag):
             current_size = len(reader.data)
             if value_offset + length > current_size:
 
-                # we coerce the chunk size to be at least the size of the tag
+                # we coerce the chunk size to be big enough to read the full tag value
                 chunk_size = max(value_offset + length - current_size, config.HEADER_CHUNK_SIZE)
                 reader.data += await reader.range_request(len(reader.data), chunk_size, is_header=True)
 

--- a/aiocogeo/tag.py
+++ b/aiocogeo/tag.py
@@ -4,7 +4,7 @@ import struct
 
 from typing import Any, Optional, Tuple, Union
 
-from .config import INGESTED_BYTES_AT_OPEN, LOG_LEVEL
+from .config import HEADER_CHUNK_SIZE, LOG_LEVEL
 from .constants import GEO_KEYS, TIFF_TAGS
 from .filesystems import Filesystem
 
@@ -85,9 +85,9 @@ class Tag(BaseTag):
             end_of_tag = reader.tell()
 
             # read more data if we need to
-            # TODO: dedup with `Filesystem.read`
+            # TODO: this will fail if chunks size is smaller than the tag value
             if value_offset + length > len(reader.data):
-                reader.data += await reader.range_request(len(reader.data), INGESTED_BYTES_AT_OPEN, is_header=True)
+                reader.data += await reader.range_request(len(reader.data), HEADER_CHUNK_SIZE, is_header=True)
 
             # read the tag value
             reader.seek(value_offset)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -9,13 +9,13 @@ async def test_block_cache_enabled(create_cog_reader, monkeypatch):
     monkeypatch.setattr(config, "ENABLE_BLOCK_CACHE", True)
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/lzw_cog.tif"
     async with create_cog_reader(infile) as cog:
-        assert cog.requests["count"] == 20
+        assert cog.requests["count"] == 2
         await cog.get_tile(0, 0, 0)
 
     async with create_cog_reader(infile) as cog:
         await cog.get_tile(0, 0, 0)
         # Confirm all requests are cached
-        assert cog.requests["count"] == 20
+        assert cog.requests["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -35,7 +35,7 @@ async def test_header_cache_enabled(create_cog_reader, monkeypatch):
     monkeypatch.setattr(config, "ENABLE_HEADER_CACHE", True)
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif"
     async with create_cog_reader(infile) as cog:
-        assert cog.requests["count"] == 20
+        assert cog.requests["count"] == 2
 
     async with create_cog_reader(infile) as cog:
         assert cog.requests["count"] == 0
@@ -49,7 +49,7 @@ async def test_header_cache_enabled(create_cog_reader, monkeypatch):
 async def test_header_cache_disabled(create_cog_reader):
     infile = "https://async-cog-reader-test-data.s3.amazonaws.com/webp_cog.tif"
     async with create_cog_reader(infile) as cog:
-        assert cog.requests["count"] == 20
+        assert cog.requests["count"] == 2
 
     async with create_cog_reader(infile) as cog:
-        assert cog.requests["count"] == 20
+        assert cog.requests["count"] == 2


### PR DESCRIPTION
Implements chunk transfer encoding.  This was already enabled through the `Filesystem.read()` method, so this mostly involved improving the efficiency of tag reading.  I did have to remove parallel tag reading (#92) since the tags are not aware of each other and would send the same 16kb request multiple times, but overall this makes things faster.

To make things simpler for now, we coerce the chunk size to be at least the minimum size required to accomplish the operation that initiated the request (ex. chunk size is 10k but reading a tag value requires 15k bytes).  This also makes it possible to [test the differences between chunk sizes](https://github.com/geospatial-jeff/aiocogeo/blob/chunk-transfer/tests/test_metadata.py#L175-L188), as setting a chunk size of 0 will essentially disable chunking for all header requests.  This could be an issue on larger images with really big offset tags, but aiocogeo doesn't support BigTiff yet anyways!

Closes #76 

## TODOs:
- [x] differentiate between `INGESTED_BYTES_AT_OPEN` and the chunk size used to request data beyond the initial request.  And make them both configurable.