### PR TITLE
fix unprediction of cog files

### DIFF
--- a/aiocogeo/cog.py
+++ b/aiocogeo/cog.py
@@ -470,7 +470,9 @@ class CompositeReader(ReaderMixin):
         self, x: int, y: int, z: int, reducer: Optional[ReduceType] = None
     ) -> List[np.ndarray]:
         """Fetch a tile from all readers"""
-        tiles = await self.map(func=lambda r: r.get_tile(x, y, z),)
+        tiles = await self.map(
+            func=lambda r: r.get_tile(x, y, z),
+        )
         reducer = reducer or self.default_reducer
         return reducer(tiles)
 

--- a/aiocogeo/compression.py
+++ b/aiocogeo/compression.py
@@ -60,7 +60,11 @@ class Compression(metaclass=abc.ABCMeta):
 
     def _reshape(self, arr: np.ndarray) -> np.ndarray:
         """Internal method to reshape an array to the size expected by the IFD"""
-        return arr.reshape(self.TileHeight.value, self.TileWidth.value, self.bands,)
+        return arr.reshape(
+            self.TileHeight.value,
+            self.TileWidth.value,
+            self.bands,
+        )
 
     def _unpredict(self, arr: np.ndarray) -> None:
         """Internal method to unpredict if there is horizontal differencing"""

--- a/aiocogeo/compression.py
+++ b/aiocogeo/compression.py
@@ -65,7 +65,7 @@ class Compression(metaclass=abc.ABCMeta):
     def _unpredict(self, arr: np.ndarray) -> None:
         """Internal method to unpredict if there is horizontal differencing"""
         if self.Predictor.value == 2:
-            imagecodecs.delta_decode(arr, out=arr, axis=-1)
+            imagecodecs.delta_decode(arr, out=arr, axis=-2)
 
     def _jpeg(self, tile: bytes) -> np.ndarray:
         """Internal method to decompress JPEG image bytes and convert to numpy array"""

--- a/aiocogeo/config.py
+++ b/aiocogeo/config.py
@@ -20,24 +20,26 @@ HEADER_CHUNK_SIZE: int = int(os.getenv("HEADER_CHUNK_SIZE", "16384"))
 
 # https://trac.osgeo.org/gdal/wiki/ConfigOptions#VSI_CACHE
 # Determines if in-memory block caching is enabled
-ENABLE_BLOCK_CACHE: bool = True if os.getenv(
-    "ENABLE_BLOCK_CACHE", "TRUE"
-).upper() == "TRUE" else False
+ENABLE_BLOCK_CACHE: bool = (
+    True if os.getenv("ENABLE_BLOCK_CACHE", "TRUE").upper() == "TRUE" else False
+)
 
 
 # enable caching of header requests, similar to GDAL's VSI CACHE
 # https://trac.osgeo.org/gdal/wiki/ConfigOptions#VSI_CACHE
-ENABLE_HEADER_CACHE: bool = True if os.getenv(
-    "ENABLE_HEADER_CACHE", "TRUE"
-).upper() == "TRUE" else False
+ENABLE_HEADER_CACHE: bool = (
+    True if os.getenv("ENABLE_HEADER_CACHE", "TRUE").upper() == "TRUE" else False
+)
 
 
 # https://trac.osgeo.org/gdal/wiki/ConfigOptions#GDAL_HTTP_MERGE_CONSECUTIVE_RANGES
 # Determines if consecutive range requests are merged into a single request, reducing the number of HTTP GET range
 # requests required to read consecutive internal image tiles
-HTTP_MERGE_CONSECUTIVE_RANGES: bool = True if os.getenv(
-    "HTTP_MERGE_CONSECUTIVE_RANGES", "FALSE"
-).upper() == "TRUE" else False
+HTTP_MERGE_CONSECUTIVE_RANGES: bool = (
+    True
+    if os.getenv("HTTP_MERGE_CONSECUTIVE_RANGES", "FALSE").upper() == "TRUE"
+    else False
+)
 
 
 # Determines if internal tiles outside the bounds of the IFD are read. When set to ``TRUE`` (default), if a partial read

--- a/tests/test_reads.py
+++ b/tests/test_reads.py
@@ -408,11 +408,7 @@ async def test_inject_session(create_cog_reader):
 
 @pytest.mark.asyncio
 async def test_cog_read_with_prediction_level_2(create_cog_reader):
-    import os
-    os.environ["CURL_CA_BUNDLE"] = "/etc/ssl/certs/ca-certificates.crt"
-    infile = (
-        "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/J/DN/2021/6/S2B_22JDN_20210601_0_L2A/TCI.tif"
-    )
+    infile = "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/J/DN/2021/6/S2B_22JDN_20210601_0_L2A/TCI.tif"
 
     async with create_cog_reader(infile) as cog:
         # Read top left tile at native resolution
@@ -432,11 +428,7 @@ async def test_cog_read_with_prediction_level_2(create_cog_reader):
             # Make sure image data is the same
             tile_arr = np.ma.getdata(tile)
             import hashlib
+
             rio_tile_hash = hashlib.md5(tile_arr.tobytes()).hexdigest()
             tile_arr_hash = hashlib.md5(rio_tile.tobytes()).hexdigest()
             assert rio_tile_hash == tile_arr_hash
-            # from matplotlib import pyplot as plt
-            # plt.imshow(tile_arr.transpose([1, 2, 0]))
-            # plt.show()
-
-    del os.environ["CURL_CA_BUNDLE"]

--- a/tests/test_reads.py
+++ b/tests/test_reads.py
@@ -404,3 +404,39 @@ async def test_inject_session(create_cog_reader):
         # Confirm session is still open
         assert not session.closed
         assert session._trace_configs
+
+
+@pytest.mark.asyncio
+async def test_cog_read_with_prediction_level_2(create_cog_reader):
+    import os
+    os.environ["CURL_CA_BUNDLE"] = "/etc/ssl/certs/ca-certificates.crt"
+    infile = (
+        "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/J/DN/2021/6/S2B_22JDN_20210601_0_L2A/TCI.tif"
+    )
+
+    async with create_cog_reader(infile) as cog:
+        # Read top left tile at native resolution
+        tile = await cog.get_tile(0, 0, 0)
+        ifd = cog.ifds[0]
+
+        # Make sure tile is the right size
+        assert tile.shape == (
+            ifd.SamplesPerPixel.value,
+            ifd.TileHeight.value,
+            ifd.TileWidth.value,
+        )
+
+        with rasterio.open(infile) as src:
+            window = Window(0, 0, ifd.TileWidth.value, ifd.TileHeight.value)
+            rio_tile = src.read(window=window)
+            # Make sure image data is the same
+            tile_arr = np.ma.getdata(tile)
+            import hashlib
+            rio_tile_hash = hashlib.md5(tile_arr.tobytes()).hexdigest()
+            tile_arr_hash = hashlib.md5(rio_tile.tobytes()).hexdigest()
+            assert rio_tile_hash == tile_arr_hash
+            # from matplotlib import pyplot as plt
+            # plt.imshow(tile_arr.transpose([1, 2, 0]))
+            # plt.show()
+
+    del os.environ["CURL_CA_BUNDLE"]

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -10,7 +10,9 @@ STAC_ITEM = "https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/
 
 @pytest.mark.asyncio
 async def test_stac_reader():
-    async with STACReader(filepath=STAC_ITEM,) as reader:
+    async with STACReader(
+        filepath=STAC_ITEM,
+    ) as reader:
         assert len(reader.readers) == 5
 
 


### PR DESCRIPTION
Hi, thank you for this library that is being  very useful to me but while using it, I found the following bug: 

COG files that were compressed with prediction level 2 are being unpredicted incorrectly. The problem is that the decoder is being applied on the wrong axis. 

Please find attached some images that show the problem:
This is the obtained image when applying the decoder on axis=1
![unprediction_error](https://user-images.githubusercontent.com/71381172/123605541-3cfee400-d7fc-11eb-8b86-ed8be134b690.png)

Obtained image applying the decoder on axis=2
![correct_prediction](https://user-images.githubusercontent.com/71381172/123605521-37090300-d7fc-11eb-8cd3-e30289af0718.png)

Also, take a look to the test called "test_cog_read_with_prediction_level_2" which validates the obtained image using rasterio.
